### PR TITLE
Provide web target for webpack

### DIFF
--- a/config/webpack/config.js
+++ b/config/webpack/config.js
@@ -5,42 +5,46 @@ const { lint, tsc } = require('./module/rules')
 const { rm, uglify } = require('./plugins');
 const { extensions, /* plugins*/ } = require('./resolve');
 const { wPackN_Ext } = require('./externals');
-//
+
+const baseConfig = {
+    entry: {
+        libR: resolve('src/lib/index.ts'),
+        "libR.min": resolve('src/lib/index.ts')
+    },
+    output: {
+        path: resolve('dist/lib'),
+        filename: '[name].js',
+        libraryTarget: 'umd2',
+        library: 'libR'
+    },
+    node: {
+        __dirname: false,
+        __filename: false,
+    },
+    devtool: 'source-map',
+    externals: [
+        wPackN_Ext() //for examples see ./externals/index.js
+    ],
+    module: {
+        rules: [
+            lint(),
+            tsc({ declaration: true })
+        ]
+    },
+    plugins: [
+        rm({ paths: ['lib'] })
+    ],
+    resolve: {
+        extensions,
+        //   plugins
+    }
+}
+
 module.exports = function(env) {
-    const configs = [{
-        target: "node",
-        entry: {
-            libR: resolve('src/lib/index.ts'),
-            "libR.min": resolve('src/lib/index.ts')
-        },
-        output: {
-            path: resolve('dist/lib'),
-            filename: '[name].js',
-            libraryTarget: 'umd2',
-            library: 'libR'
-        },
-        node: {
-            __dirname: false,
-            __filename: false,
-        },
-        devtool: 'source-map',
-        externals: [
-            wPackN_Ext() //for examples see ./externals/index.js
-        ],
-        module: {
-            rules: [
-                lint(),
-                tsc({ declaration: true })
-            ]
-        },
-        plugins: [
-            rm({ paths: ['lib'] })
-        ],
-        resolve: {
-            extensions,
-            //   plugins
-        },
-    }];
+    const configs = [
+      { ...baseConfig, target: 'node' },
+      { ...baseConfig, target: 'web' },
+    ];
 
     //env specific adjustments
     if (/prod/i.test(env)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "author": "Jacob K.F. Bogers",
-    "browser:disabled": "./dist/client/bundle.js",
+    "browser": "./dist/web/libR.js",
     "browser:doc": "https://github.com/defunctzombie/package-browser-field-spec",
     "bugs": {
         "url": "https://github.com/jacobbogers/libRmath.js/issues"


### PR DESCRIPTION
This fixes an issue I was running into in my project when trying to use webpack with `target: web` and then including `lib-r-math.js`. It looked like it was trying to use the libRmath.js code that was compiled for node since there was no suitable version for web. 

I modified the webpack config to create a target for web, and then specified in `package.json` the `browser` field to point to the web bundled `dist/web/libR.js` and that seems to have done the trick. 

Not sure if this is the best solution but hopefully it helps. 

Thanks to you for this great package and all the hard work in putting it together. 