### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 {
   "language": "node_js",
-  "node_js": "node",
+  "node_js": [
+    "node",
+    "10",
+    "8",
+    "6"
+  ],
   "cache": {
     "directories": [
       "node_modules"


### PR DESCRIPTION
We should run the tests on all current LTS branches of Node.js which are 6, 8 and 10. See https://github.com/nodejs/Release/blob/master/README.md