### PR TITLE
better typescript support

### DIFF
--- a/src/lib/rng/irng.ts
+++ b/src/lib/rng/irng.ts
@@ -4,6 +4,9 @@ import { IRNGType } from './irng-type';
 
 export type MessageType = 'INIT';
 
+// cache it, make without create seq() every time
+export const segFnCache = seq();
+
 export abstract class IRNG {
   protected _name: string;
   protected _kind: IRNGType;
@@ -42,7 +45,7 @@ export abstract class IRNG {
   public unif_rand(n: number): number | number[];
   public unif_rand(n: number = 1): number | number[] {
     n = (!n || n < 0) ? 1 : n;
-    return map(seq()()(n))(() => this.internal_unif_rand());
+    return map(segFnCache()(n))(() => this.internal_unif_rand());
   }
 
   protected abstract internal_unif_rand(): number;

--- a/src/lib/rng/irng.ts
+++ b/src/lib/rng/irng.ts
@@ -36,6 +36,10 @@ export abstract class IRNG {
   }
 
   public abstract set seed(_seed: number[]);
+
+  public unif_rand(): number;
+  public unif_rand(n: 0 | 1): number;
+  public unif_rand(n: number): number | number[];
   public unif_rand(n: number = 1): number | number[] {
     n = (!n || n < 0) ? 1 : n;
     return map(seq()()(n))(() => this.internal_unif_rand());

--- a/src/lib/rng/normal/inormal-rng.ts
+++ b/src/lib/rng/normal/inormal-rng.ts
@@ -1,4 +1,5 @@
 import { IRNG } from '../';
+import { segFnCache } from '../irng';
 import { map, seq } from '../../r-func';
 
 export abstract class IRNGNormal {
@@ -15,8 +16,8 @@ export abstract class IRNGNormal {
   public norm_rand(n: number): number | number[];
   public norm_rand(n: number = 1): number|number[]{
     n = !n || n < 0 ? 1 : n;
-    return map(seq()()(n))(() => this.internal_norm_rand());
-  } 
+    return map(segFnCache()(n))(() => this.internal_norm_rand());
+  }
 
   protected abstract internal_norm_rand(): number;
 

--- a/src/lib/rng/normal/inormal-rng.ts
+++ b/src/lib/rng/normal/inormal-rng.ts
@@ -10,6 +10,9 @@ export abstract class IRNGNormal {
     this.internal_norm_rand = this.internal_norm_rand.bind(this);
   }
 
+  public norm_rand(): number;
+  public norm_rand(n: 0 | 1): number;
+  public norm_rand(n: number): number | number[];
   public norm_rand(n: number = 1): number|number[]{
     n = !n || n < 0 ? 1 : n;
     return map(seq()()(n))(() => this.internal_norm_rand());
@@ -17,6 +20,9 @@ export abstract class IRNGNormal {
 
   protected abstract internal_norm_rand(): number;
 
+  public unif_rand(): number;
+  public unif_rand(n: 0 | 1): number;
+  public unif_rand(n: number): number | number[];
   public unif_rand(n: number = 1): number|number[] {
      return this.rng.unif_rand(n);
   }


### PR DESCRIPTION
mocha --require ts-node/register lib-r-math.js.npm.test.ts
```
  libRmath.rng.KnuthTAOCP
    √ KnuthTAOCP is extend of libRmath.IRNG (58ms)
    √ typeof .internal_unif_rand() == 'number'
    √ typeof .unif_rand() == 'number'
    √ typeof .unif_rand(0) == 'number'
    √ typeof .unif_rand(10) is number[]

  libRmath.rng.KnuthTAOCP2002
    √ KnuthTAOCP2002 is extend of libRmath.IRNG
    √ typeof .internal_unif_rand() == 'number'
    √ typeof .unif_rand() == 'number'
    √ typeof .unif_rand(0) == 'number'
    √ typeof .unif_rand(10) is number[]

  libRmath.rng.LecuyerCMRG
    √ LecuyerCMRG is extend of libRmath.IRNG
    √ typeof .internal_unif_rand() == 'number'
    √ typeof .unif_rand() == 'number'
    √ typeof .unif_rand(0) == 'number'
    √ typeof .unif_rand(10) is number[]

  libRmath.rng.MarsagliaMultiCarry
    √ MarsagliaMultiCarry is extend of libRmath.IRNG
    √ typeof .internal_unif_rand() == 'number'
    √ typeof .unif_rand() == 'number'
    √ typeof .unif_rand(0) == 'number'
    √ typeof .unif_rand(10) is number[]

  libRmath.rng.MersenneTwister
    √ MersenneTwister is extend of libRmath.IRNG
    √ typeof .internal_unif_rand() == 'number'
    √ typeof .unif_rand() == 'number'
    √ typeof .unif_rand(0) == 'number'
    √ typeof .unif_rand(10) is number[]

  libRmath.rng.SuperDuper
    √ SuperDuper is extend of libRmath.IRNG
    √ typeof .internal_unif_rand() == 'number'
    √ typeof .unif_rand() == 'number'
    √ typeof .unif_rand(0) == 'number'
    √ typeof .unif_rand(10) is number[]

  libRmath.rng.WichmannHill
    √ WichmannHill is extend of libRmath.IRNG
    √ typeof .internal_unif_rand() == 'number'
    √ typeof .unif_rand() == 'number'
    √ typeof .unif_rand(0) == 'number'
    √ typeof .unif_rand(10) is number[]

  libRmath.rng.normal.AhrensDieter
    √ AhrensDieter is extend of libRmath.IRNGNormal
    √ typeof .internal_norm_rand() == 'number'
    √ typeof .norm_rand() == 'number'
    √ typeof .norm_rand(0) == 'number'
    √ typeof .norm_rand(1) == 'number'
    √ typeof .norm_rand(10) is number[]
    √ typeof .unif_rand() == 'number'
    √ typeof .unif_rand(0) == 'number'
    √ typeof .unif_rand(1) == 'number'
    √ typeof .unif_rand(10) is number[]

  libRmath.rng.normal.BoxMuller
    √ BoxMuller is extend of libRmath.IRNGNormal
    √ typeof .internal_norm_rand() == 'number'
    √ typeof .norm_rand() == 'number'
    √ typeof .norm_rand(0) == 'number'
    √ typeof .norm_rand(1) == 'number'
    √ typeof .norm_rand(10) is number[]
    √ typeof .unif_rand() == 'number'
    √ typeof .unif_rand(0) == 'number'
    √ typeof .unif_rand(1) == 'number'
    √ typeof .unif_rand(10) is number[]

  libRmath.rng.normal.BuggyKindermanRamage
    √ BuggyKindermanRamage is extend of libRmath.IRNGNormal
    √ typeof .internal_norm_rand() == 'number'
    √ typeof .norm_rand() == 'number'
    √ typeof .norm_rand(0) == 'number'
    √ typeof .norm_rand(1) == 'number'
    √ typeof .norm_rand(10) is number[]
    √ typeof .unif_rand() == 'number'
    √ typeof .unif_rand(0) == 'number'
    √ typeof .unif_rand(1) == 'number'
    √ typeof .unif_rand(10) is number[]

  libRmath.rng.normal.Inversion
    √ Inversion is extend of libRmath.IRNGNormal
    √ typeof .internal_norm_rand() == 'number'
    √ typeof .norm_rand() == 'number'
    √ typeof .norm_rand(0) == 'number'
    √ typeof .norm_rand(1) == 'number'
    √ typeof .norm_rand(10) is number[]
    √ typeof .unif_rand() == 'number'
    √ typeof .unif_rand(0) == 'number'
    √ typeof .unif_rand(1) == 'number'
    √ typeof .unif_rand(10) is number[]

  libRmath.rng.normal.KindermanRamage
    √ KindermanRamage is extend of libRmath.IRNGNormal
    √ typeof .internal_norm_rand() == 'number'
    √ typeof .norm_rand() == 'number'
    √ typeof .norm_rand(0) == 'number'
    √ typeof .norm_rand(1) == 'number'
    √ typeof .norm_rand(10) is number[]
    √ typeof .unif_rand() == 'number'
    √ typeof .unif_rand(0) == 'number'
    √ typeof .unif_rand(1) == 'number'
    √ typeof .unif_rand(10) is number[]

```


```ts
import libRmath = require('lib-r-math.js');

let rs = Object.entries(libRmath.rng)
	.reduce(function (a, [rngKey, RNG])
	{
		const seed = 11111111;
		let isExtend: boolean;
		let rng: libRmath.IRNG & {
			internal_unif_rand(): number;
		}

		try
		{
			// @ts-ignore
			rng = new RNG(seed);

			isExtend = (rng instanceof libRmath.IRNG)
		}
		catch (e)
		{

		}

		if (isExtend)
		{
			a.rng[rngKey] = RNG
		}
		else
		{
			a.rnglist[rngKey] = RNG
		}

		return a;
	}, {
		rng: {},
		rnglist: {},
	})
;

Object.entries(rs.rng)
	.forEach(function ([rngKey, RNG])
	{
		describe(`libRmath.rng.${rngKey}`, () =>
		{
			const seed = 0;

			let isExtend: boolean;
			let rng: libRmath.IRNG & {
				internal_unif_rand(): number;
			}

			try
			{
				// @ts-ignore
				rng = new RNG(seed);

				isExtend = (rng instanceof libRmath.IRNG)
			}
			catch (e)
			{

			}

			if (isExtend)
			{
				it(`${rngKey} is extend of libRmath.IRNG`, function ()
				{
					// @ts-ignore
					let actual = new RNG(seed);
					let expected;

					expect(actual)
						.instanceOf(libRmath.IRNG)
					;
				});

				it(`typeof .internal_unif_rand() == 'number'`, function ()
				{
					let actual = rng.internal_unif_rand();
					let expected;

					expect(actual).is.a('number')
					;
				});

				it(`typeof .unif_rand() == 'number'`, function ()
				{
					let actual = rng.unif_rand();
					let expected;

					expect(actual).is.a('number')
					;
				});

				it(`typeof .unif_rand(0) == 'number'`, function ()
				{
					let actual = rng.unif_rand(0);
					let expected;

					expect(actual).is.a('number')
					;
				});

				it(`typeof .unif_rand(10) is number[]`, function ()
				{
					let actual = rng.unif_rand(10);
					let expected;

					expect(actual).is.a('array')
					;
				});

			}

		})
		;
	});

Object.entries(rs.rnglist)
	.forEach(function ([rsName, rsList])
	{
		let _rng = new libRmath.rng.MersenneTwister()

		Object.entries(rsList)
			.forEach(function ([rngKey, RNG])
			{
				describe(`libRmath.rng.${rsName}.${rngKey}`, () =>
				{
					let isExtend: boolean;
					let rng: libRmath.IRNGNormal & {
						internal_norm_rand(): number;
					}

					try
					{
						rng = new RNG(_rng);

						isExtend = (rng instanceof libRmath.IRNGNormal)
					}
					catch (e)
					{

					}

					it(`${rngKey} is extend of libRmath.IRNGNormal`, function ()
					{
						let actual = new RNG(_rng);
						let expected;

						expect(actual)
							.instanceOf(libRmath.IRNGNormal)
						;
					});

					if (isExtend)
					{

						it(`typeof .internal_norm_rand() == 'number'`, function ()
						{
							let actual = rng.internal_norm_rand();
							let expected;

							expect(actual).is.a('number')
							;
						});

						it(`typeof .norm_rand() == 'number'`, function ()
						{
							let actual = rng.norm_rand();
							let expected;

							expect(actual).is.a('number')
							;
						});

						it(`typeof .norm_rand(0) == 'number'`, function ()
						{
							let actual = rng.norm_rand(0);
							let expected;

							expect(actual).is.a('number')
							;
						});

						it(`typeof .norm_rand(1) == 'number'`, function ()
						{
							let actual = rng.norm_rand(1);
							let expected;

							expect(actual).is.a('number')
							;
						});

						it(`typeof .norm_rand(10) is number[]`, function ()
						{
							let actual = rng.norm_rand(10);
							let expected;

							expect(actual).is.a('array')
							;
						});

						it(`typeof .unif_rand() == 'number'`, function ()
						{
							let actual = rng.unif_rand();
							let expected;

							expect(actual).is.a('number')
							;
						});

						it(`typeof .unif_rand(0) == 'number'`, function ()
						{
							let actual = rng.unif_rand(0);
							let expected;

							expect(actual).is.a('number')
							;
						});

						it(`typeof .unif_rand(1) == 'number'`, function ()
						{
							let actual = rng.unif_rand(1);
							let expected;

							expect(actual).is.a('number')
							;
						});

						it(`typeof .unif_rand(10) is number[]`, function ()
						{
							let actual = rng.unif_rand(10);
							let expected;

							expect(actual).is.a('array')
							;
						});

					}

				})
				;
			});
	})
;
```