### PR TITLE
fix bratio, erfc1, and brcmp1 in toms708 code

### DIFF
--- a/src/lib/common/toms708/toms708.ts
+++ b/src/lib/common/toms708/toms708.ts
@@ -1679,7 +1679,7 @@ export class Toms708 {
         }
       }
 
-      if (Math.max(a0, b0) > 1.0) {
+      if (Math.max(a0, b0) <= 1.0) {
         if (a0 >= Math.min(0.2, b0) || Math.pow(x0, a0) <= 0.9) {
           w.val = Toms708.bpser(a0, b0, x0, eps);
           w1.val = 0.5 + (0.5 - w.val);

--- a/src/lib/common/toms708/toms708.ts
+++ b/src/lib/common/toms708/toms708.ts
@@ -1260,7 +1260,7 @@ export class Toms708 {
       }
 
       let z = a * lnx + b * lny;
-      if (a0 <= 1.0) {
+      if (a0 >= 1.0) {
         z -= Toms708.betaln(a, b);
         return Toms708.esum(mu, z);
       }
@@ -2310,12 +2310,12 @@ export class Toms708 {
           p[6]) *
         ax +
         p[7];
-      bot =
-        ((((((q[0] * ax + q[2]) * ax + q[2]) * ax + q[3]) * ax + q[5]) * ax +
-          q[5]) *
-          ax +
-          q[6]) *
-        ax +
+      bot = 
+        ((((((q[0] * ax + q[1]) * ax + q[2]) * ax + q[3]) * ax + q[4]) * ax +
+          q[5]) * 
+          ax + 
+          q[6]) * 
+        ax + 
         q[7];
       dResult = top / bot;
     } else {

--- a/src/lib/common/toms708/toms708.ts
+++ b/src/lib/common/toms708/toms708.ts
@@ -1643,7 +1643,7 @@ export class Toms708 {
       // C
       // C  PROCEDURE FOR A0 <= 1 OR B0 <= 1
       // C
-      if (x <= 0.5) {
+      if (x > 0.5) {
         ind = 1;
         a0 = b;
         b0 = a;

--- a/src/lib/common/toms708/toms708.ts
+++ b/src/lib/common/toms708/toms708.ts
@@ -1679,7 +1679,7 @@ export class Toms708 {
         }
       }
 
-      if (Math.max(a0, b0) <= 1.0) {
+      if (Math.max(a0, b0) > 1.0) {
         if (a0 >= Math.min(0.2, b0) || Math.pow(x0, a0) <= 0.9) {
           w.val = Toms708.bpser(a0, b0, x0, eps);
           w1.val = 0.5 + (0.5 - w.val);


### PR DESCRIPTION
Fixes issue in https://github.com/R-js/libRmath.js/issues/39. 

Given the importance of these functions, it likely fixes other bugs as well.

* Change in `brcmp1` (line 1263) can be compared to [Line 973](https://github.com/wch/r-source/blob/761af23c85f6d0062a88fe86fdaa269c82591ce8/src/nmath/toms708.c#L973) in R's `toms708.c`.

* Change in `bratio` (line 1646) can be compared to [Line 186](https://github.com/wch/r-source/blob/761af23c85f6d0062a88fe86fdaa269c82591ce8/src/nmath/toms708.c#L186) in R's `toms708.c`.

* Change in `erfc1` (line 2313) can be compared to [Line 1670](https://github.com/wch/r-source/blob/761af23c85f6d0062a88fe86fdaa269c82591ce8/src/nmath/toms708.c#L1670) in R's `toms708.c`.
