### PR TITLE
put ts path aliases in jest.config.js, test now working, next gamma

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -25,5 +25,8 @@ module.exports = {
     },
     moduleNameMapper: {
         '^\\$jest-extension$': '<rootDir>/src/packages/jest-extension.ts',
+        '^@distributions/(.*)$': '<rootDir>/src/lib/distributions/$1',
+        '^@common/(.*)$': '<rootDir>/src/packages/common/$1',
+        '^\\$constants$': '<rootDir>/src/lib/common/_general.ts',
     },
 };

--- a/src/lib/alt/log/index.ts
+++ b/src/lib/alt/log/index.ts
@@ -15,4 +15,3 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 export * from './log1p';
-

--- a/src/lib/alt/log/log1p.ts
+++ b/src/lib/alt/log/log1p.ts
@@ -26,7 +26,7 @@ const {
     isFinite: R_FINITE,
 } = Number;
 import { chebyshev_eval } from '../../chebyshev/index';
-import { ME, ML_ERR_return_NAN, ML_ERROR } from '../../common/_general';
+import { ME, ML_ERR_return_NAN, ML_ERROR } from '@common/logger';
 
 //import { chebyshev_eval } from '../exp/expm1'chebyshev';
 

--- a/src/lib/distributions/exp/expm1.ts
+++ b/src/lib/distributions/exp/expm1.ts
@@ -14,7 +14,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-import { M_LN2, R_D_Cval, R_D_log, R_D_Lval } from '../common/_general';
+import { M_LN2, R_D_Cval, R_D_log, R_D_Lval } from '$constants';
 
 //import { log1p } from '../exp/expm1'log';
 

--- a/src/lib/distributions/normal/index.ts
+++ b/src/lib/distributions/normal/index.ts
@@ -21,16 +21,16 @@ import { qnorm } from './qnorm';
 import { rnorm as _rnorm } from './rnorm';
 
 import { IRNGNormal, rng as _rng } from '../rng';
-const { normal: { Inversion } } = _rng;
-
+const {
+    normal: { Inversion },
+} = _rng;
 
 export function Normal(prng: IRNGNormal = new Inversion()) {
-
-  return {
-    rnorm: (n = 1, mu = 0, sigma = 1) => _rnorm(n, mu, sigma, prng),
-    dnorm,
-    pnorm,
-    qnorm,
-    rng: prng,
-  };
+    return {
+        rnorm: (n = 1, mu = 0, sigma = 1) => _rnorm(n, mu, sigma, prng),
+        dnorm,
+        pnorm,
+        qnorm,
+        rng: prng,
+    };
 }

--- a/src/lib/rng/normal/inversion/index.ts
+++ b/src/lib/rng/normal/inversion/index.ts
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 import { IRNG, MessageType } from '../../irng';
 // dependency how to handle this in bundle
-import { qnorm } from '../../../normal/qnorm';
+import { qnorm } from '@distributions/normal/qnorm';
 import { MersenneTwister } from '../../mersenne-twister';
 import { IRNGNormal } from '../normal-rng';
 import { IRNGNormalTypeEnum } from '../in01-type';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -112,6 +112,9 @@
       ],
       "@trig/*": [
         "lib/trigonometry/*"
+      ],
+      "@distributions/*" :[
+        "lib/distributions/*"
       ]
     }, // maybe use later, if you decide to use this, specify baseurl
     // source maps


### PR DESCRIPTION
- typescript path aliases need to be repolicated in "moduleNames" in jest configfiles
- all unit test are working with 100% code coverage
- next on the list is gamma and lgamma coverage test (100%) , full fidelity with R