### PR TITLE
Patch 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## version 2.0.1 -
+## version 2.0.1 - 2024-05-05
+
+### fixed (Maddison Hellstrom)[github](https://github.com/b0o) 
+
+[PR 190](https://github.com/R-js/libRmath.js/pull/190)
+
+- `./types`  added to package.json "exports" property
 
 ### improved (Jacob Bogers <jkfbogers@gmail.com>)
 
--   removed `ts-patch` to resolve alias path, use `ts-node` instead
--   introduced `prettier`
--   use prettier semver 2.8.8 to make it work with current libs
+-   removed `ts-patch`
+-   removed `ts-node`
+-   removed `prettier`
+-   removed `eslint`
+-   removed `babel`
+-   removed `typescript-eslint`
+-   removed `typescript-eslint/parser`
+-   updated `typescript` to v4.5.2
+-   removed `typescript-eslint-language-service`
+-   removed  `typescript-transform-paths/register`
+
+
+
 
 ## version 2.0.0 - 2023-03-03
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,20 +22,14 @@
                 "@types/node": "18.11.10",
                 "@typescript-eslint/eslint-plugin": "5.45.1",
                 "@typescript-eslint/parser": "5.45.1",
-                "acorn": "8.8.1",
-                "escodegen": "2.0.0",
-                "eslint": "8.29.0",
-                "eslint-config-prettier": "8.8.0",
-                "eslint-plugin-prettier": "5.0.0",
+                "acorn": "8.11.3",
+                "escodegen": "2.1.0",
                 "jest": "29.3.1",
                 "ms": "3.0.0-canary.1",
-                "prettier": "2.8.8",
                 "rollup": "3.6.0",
                 "ts-jest": "29.0.3",
                 "ts-node": "10.9.1",
-                "typescript": "4.4.4",
-                "typescript-eslint-language-service": "4.1.5",
-                "typescript-transform-paths": "3.4.4"
+                "typescript": "4.4.4"
             },
             "engines": {
                 "node": ">=v16.18.1"
@@ -733,6 +727,7 @@
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
             "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
@@ -756,6 +751,7 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
             "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@humanwhocodes/object-schema": "^1.2.1",
                 "debug": "^4.1.1",
@@ -770,6 +766,7 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
             "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=12.22"
             },
@@ -782,7 +779,8 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
@@ -1302,32 +1300,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/@pkgr/utils": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
-            "integrity": "sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==",
-            "dev": true,
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "fast-glob": "^3.3.0",
-                "is-glob": "^4.0.3",
-                "open": "^9.1.0",
-                "picocolors": "^1.0.0",
-                "tslib": "^2.6.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/unts"
-            }
-        },
-        "node_modules/@pkgr/utils/node_modules/tslib": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true
-        },
         "node_modules/@rollup/plugin-node-resolve": {
             "version": "15.0.1",
             "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.0.1.tgz",
@@ -1772,9 +1744,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.8.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-            "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+            "version": "8.11.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -1788,6 +1760,7 @@
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
+            "peer": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
@@ -1806,6 +1779,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -1891,7 +1865,8 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/array-union": {
             "version": "2.1.0",
@@ -1999,27 +1974,6 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
-        "node_modules/big-integer": {
-            "version": "1.6.51",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.6"
-            }
-        },
-        "node_modules/bplist-parser": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
-            "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
-            "dev": true,
-            "dependencies": {
-                "big-integer": "^1.6.44"
-            },
-            "engines": {
-                "node": ">= 5.10.0"
-            }
-        },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2104,21 +2058,6 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/bundle-name": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
-            "integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
-            "dev": true,
-            "dependencies": {
-                "run-applescript": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -2323,7 +2262,8 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/deepmerge": {
             "version": "4.2.2",
@@ -2332,162 +2272,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/default-browser": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
-            "integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
-            "dev": true,
-            "dependencies": {
-                "bundle-name": "^3.0.0",
-                "default-browser-id": "^3.0.0",
-                "execa": "^7.1.1",
-                "titleize": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/default-browser-id": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
-            "integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
-            "dev": true,
-            "dependencies": {
-                "bplist-parser": "^0.2.0",
-                "untildify": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/default-browser/node_modules/execa": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-7.1.1.tgz",
-            "integrity": "sha512-wH0eMf/UXckdUYnO21+HDztteVv05rq2GXksxT4fCGeHkBhw1DROXh40wcjMcRqDOWE7iPJ4n3M7e2+YFP+76Q==",
-            "dev": true,
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.1",
-                "human-signals": "^4.3.0",
-                "is-stream": "^3.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^5.1.0",
-                "onetime": "^6.0.0",
-                "signal-exit": "^3.0.7",
-                "strip-final-newline": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/default-browser/node_modules/human-signals": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
-            "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=14.18.0"
-            }
-        },
-        "node_modules/default-browser/node_modules/is-stream": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-            "dev": true,
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/default-browser/node_modules/mimic-fn": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/default-browser/node_modules/npm-run-path": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-            "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
-            "dev": true,
-            "dependencies": {
-                "path-key": "^4.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/default-browser/node_modules/onetime": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-            "dev": true,
-            "dependencies": {
-                "mimic-fn": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/default-browser/node_modules/path-key": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/default-browser/node_modules/strip-final-newline": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/define-lazy-prop": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/detect-newline": {
@@ -2534,6 +2318,7 @@
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
             "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "esutils": "^2.0.2"
             },
@@ -2588,6 +2373,7 @@
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -2596,15 +2382,14 @@
             }
         },
         "node_modules/escodegen": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
-            "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+            "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
             "dev": true,
             "dependencies": {
                 "esprima": "^4.0.1",
                 "estraverse": "^5.2.0",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1"
+                "esutils": "^2.0.2"
             },
             "bin": {
                 "escodegen": "bin/escodegen.js",
@@ -2622,6 +2407,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
             "integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@eslint/eslintrc": "^1.3.3",
                 "@humanwhocodes/config-array": "^0.11.6",
@@ -2671,47 +2457,6 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/eslint-config-prettier": {
-            "version": "8.8.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
-            "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
-            "dev": true,
-            "bin": {
-                "eslint-config-prettier": "bin/cli.js"
-            },
-            "peerDependencies": {
-                "eslint": ">=7.0.0"
-            }
-        },
-        "node_modules/eslint-plugin-prettier": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
-            "integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
-            "dev": true,
-            "dependencies": {
-                "prettier-linter-helpers": "^1.0.0",
-                "synckit": "^0.8.5"
-            },
-            "engines": {
-                "node": "^14.18.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/prettier"
-            },
-            "peerDependencies": {
-                "@types/eslint": ">=8.0.0",
-                "eslint": ">=8.0.0",
-                "prettier": ">=3.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/eslint": {
-                    "optional": true
-                },
-                "eslint-config-prettier": {
-                    "optional": true
-                }
             }
         },
         "node_modules/eslint-rule-composer": {
@@ -2786,6 +2531,7 @@
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
             "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
@@ -2799,6 +2545,7 @@
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
             "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
@@ -2816,6 +2563,7 @@
             "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
             "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "acorn": "^8.8.0",
                 "acorn-jsx": "^5.3.2",
@@ -2846,6 +2594,7 @@
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
             "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "estraverse": "^5.1.0"
             },
@@ -2941,13 +2690,8 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true
-        },
-        "node_modules/fast-diff": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-            "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/fast-glob": {
             "version": "3.3.0",
@@ -2987,7 +2731,8 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/fastq": {
             "version": "1.15.0",
@@ -3012,6 +2757,7 @@
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
             "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "flat-cache": "^3.0.4"
             },
@@ -3036,6 +2782,7 @@
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
@@ -3052,6 +2799,7 @@
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
             "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "flatted": "^3.1.0",
                 "rimraf": "^3.0.2"
@@ -3064,7 +2812,8 @@
             "version": "3.2.7",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
             "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
@@ -3156,6 +2905,7 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "is-glob": "^4.0.3"
             },
@@ -3168,6 +2918,7 @@
             "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
             "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
             },
@@ -3208,7 +2959,8 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
             "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/has": {
             "version": "1.0.3",
@@ -3260,6 +3012,7 @@
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
             "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -3348,21 +3101,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-docker": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-            "dev": true,
-            "bin": {
-                "is-docker": "cli.js"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3402,24 +3140,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-inside-container": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-            "dev": true,
-            "dependencies": {
-                "is-docker": "^3.0.0"
-            },
-            "bin": {
-                "is-inside-container": "cli.js"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/is-module": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -3440,6 +3160,7 @@
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
             "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -3449,33 +3170,6 @@
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "dev": true,
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-wsl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-            "dev": true,
-            "dependencies": {
-                "is-docker": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/is-wsl/node_modules/is-docker": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-            "dev": true,
-            "bin": {
-                "is-docker": "cli.js"
-            },
             "engines": {
                 "node": ">=8"
             },
@@ -4128,6 +3822,7 @@
             "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
             "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
             "dev": true,
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/js-sdsl"
@@ -4144,6 +3839,7 @@
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
             "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -4173,13 +3869,15 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/json5": {
             "version": "2.2.3",
@@ -4216,6 +3914,7 @@
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
@@ -4235,6 +3934,7 @@
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "p-locate": "^5.0.0"
             },
@@ -4255,7 +3955,8 @@
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/lru-cache": {
             "version": "5.1.1",
@@ -4431,75 +4132,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/open": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
-            "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
-            "dev": true,
-            "dependencies": {
-                "default-browser": "^4.0.0",
-                "define-lazy-prop": "^3.0.0",
-                "is-inside-container": "^1.0.0",
-                "is-wsl": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/optionator": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-            "dev": true,
-            "dependencies": {
-                "deep-is": "~0.1.3",
-                "fast-levenshtein": "~2.0.6",
-                "levn": "~0.3.0",
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2",
-                "word-wrap": "~1.2.3"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/optionator/node_modules/levn": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-            "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-            "dev": true,
-            "dependencies": {
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/optionator/node_modules/prelude-ls": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-            "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/optionator/node_modules/type-check": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-            "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-            "dev": true,
-            "dependencies": {
-                "prelude-ls": "~1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
         "node_modules/p-limit": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -4520,6 +4152,7 @@
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "p-limit": "^3.0.2"
             },
@@ -4544,6 +4177,7 @@
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "callsites": "^3.0.0"
             },
@@ -4707,35 +4341,9 @@
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/prettier": {
-            "version": "2.8.8",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-            "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-            "dev": true,
-            "bin": {
-                "prettier": "bin-prettier.js"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            },
-            "funding": {
-                "url": "https://github.com/prettier/prettier?sponsor=1"
-            }
-        },
-        "node_modules/prettier-linter-helpers": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-            "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-            "dev": true,
-            "dependencies": {
-                "fast-diff": "^1.1.2"
-            },
-            "engines": {
-                "node": ">=6.0.0"
             }
         },
         "node_modules/pretty-format": {
@@ -4782,6 +4390,7 @@
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
             "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -4876,6 +4485,7 @@
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -4904,6 +4514,7 @@
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
             "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -4928,21 +4539,6 @@
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
-            }
-        },
-        "node_modules/run-applescript": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
-            "integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
-            "dev": true,
-            "dependencies": {
-                "execa": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/run-parallel": {
@@ -5182,28 +4778,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/synckit": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
-            "integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
-            "dev": true,
-            "dependencies": {
-                "@pkgr/utils": "^2.3.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": "^14.18.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/unts"
-            }
-        },
-        "node_modules/synckit/node_modules/tslib": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true
-        },
         "node_modules/terser": {
             "version": "5.16.1",
             "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
@@ -5250,19 +4824,8 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-            "dev": true
-        },
-        "node_modules/titleize": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
-            "integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
             "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
+            "peer": true
         },
         "node_modules/tmpl": {
             "version": "1.0.5",
@@ -5403,6 +4966,7 @@
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1"
             },
@@ -5424,6 +4988,7 @@
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -5442,38 +5007,6 @@
             },
             "engines": {
                 "node": ">=4.2.0"
-            }
-        },
-        "node_modules/typescript-eslint-language-service": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/typescript-eslint-language-service/-/typescript-eslint-language-service-4.1.5.tgz",
-            "integrity": "sha512-lJ9tH53m8e8fYYwhG5hTpiUHCz4SjY55rT8T4ADrmF/29JPdWkUik8cbZy+KsCsUIG1CEMRz+DOV4S+wVyYivQ==",
-            "dev": true,
-            "peerDependencies": {
-                "@typescript-eslint/parser": ">= 4.0.0",
-                "eslint": ">= 6.7.0 <= 6.8.x || >= 7.0.0",
-                "typescript": ">= 3.0.0 || >= 4.0.0"
-            }
-        },
-        "node_modules/typescript-transform-paths": {
-            "version": "3.4.4",
-            "resolved": "https://registry.npmjs.org/typescript-transform-paths/-/typescript-transform-paths-3.4.4.tgz",
-            "integrity": "sha512-b+6JTpJbO9CxVyt9+fIKXpLNUEyzrKXdflsVo/nXbQqelCYkpSsRdI+ikg3SelyE04rUeKlb+Kdt1D8Doa9JoQ==",
-            "dev": true,
-            "dependencies": {
-                "minimatch": "^3.0.4"
-            },
-            "peerDependencies": {
-                "typescript": ">=3.6.5"
-            }
-        },
-        "node_modules/untildify": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
-            "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/update-browserslist-db": {
@@ -5507,6 +5040,7 @@
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "punycode": "^2.1.0"
             }
@@ -5566,6 +5100,7 @@
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
             "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -6197,6 +5732,7 @@
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
             "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
@@ -6214,6 +5750,7 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
             "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@humanwhocodes/object-schema": "^1.2.1",
                 "debug": "^4.1.1",
@@ -6224,13 +5761,15 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
             "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "@humanwhocodes/object-schema": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
@@ -6645,28 +6184,6 @@
                 "fastq": "^1.6.0"
             }
         },
-        "@pkgr/utils": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
-            "integrity": "sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==",
-            "dev": true,
-            "requires": {
-                "cross-spawn": "^7.0.3",
-                "fast-glob": "^3.3.0",
-                "is-glob": "^4.0.3",
-                "open": "^9.1.0",
-                "picocolors": "^1.0.0",
-                "tslib": "^2.6.0"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.6.0",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-                    "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true
-                }
-            }
-        },
         "@rollup/plugin-node-resolve": {
             "version": "15.0.1",
             "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.0.1.tgz",
@@ -6989,9 +6506,9 @@
             }
         },
         "acorn": {
-            "version": "8.8.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-            "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+            "version": "8.11.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "dev": true
         },
         "acorn-jsx": {
@@ -6999,6 +6516,7 @@
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
+            "peer": true,
             "requires": {}
         },
         "acorn-walk": {
@@ -7012,6 +6530,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -7071,7 +6590,8 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "array-union": {
             "version": "2.1.0",
@@ -7155,21 +6675,6 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
-        "big-integer": {
-            "version": "1.6.51",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-            "dev": true
-        },
-        "bplist-parser": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
-            "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
-            "dev": true,
-            "requires": {
-                "big-integer": "^1.6.44"
-            }
-        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -7230,15 +6735,6 @@
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
             "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
             "dev": true
-        },
-        "bundle-name": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
-            "integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
-            "dev": true,
-            "requires": {
-                "run-applescript": "^5.0.0"
-            }
         },
         "callsites": {
             "version": "3.1.0",
@@ -7386,107 +6882,13 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "deepmerge": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
             "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-            "dev": true
-        },
-        "default-browser": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
-            "integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
-            "dev": true,
-            "requires": {
-                "bundle-name": "^3.0.0",
-                "default-browser-id": "^3.0.0",
-                "execa": "^7.1.1",
-                "titleize": "^3.0.0"
-            },
-            "dependencies": {
-                "execa": {
-                    "version": "7.1.1",
-                    "resolved": "https://registry.npmjs.org/execa/-/execa-7.1.1.tgz",
-                    "integrity": "sha512-wH0eMf/UXckdUYnO21+HDztteVv05rq2GXksxT4fCGeHkBhw1DROXh40wcjMcRqDOWE7iPJ4n3M7e2+YFP+76Q==",
-                    "dev": true,
-                    "requires": {
-                        "cross-spawn": "^7.0.3",
-                        "get-stream": "^6.0.1",
-                        "human-signals": "^4.3.0",
-                        "is-stream": "^3.0.0",
-                        "merge-stream": "^2.0.0",
-                        "npm-run-path": "^5.1.0",
-                        "onetime": "^6.0.0",
-                        "signal-exit": "^3.0.7",
-                        "strip-final-newline": "^3.0.0"
-                    }
-                },
-                "human-signals": {
-                    "version": "4.3.1",
-                    "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
-                    "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
-                    "dev": true
-                },
-                "is-stream": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-                    "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-                    "dev": true
-                },
-                "mimic-fn": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-                    "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-                    "dev": true
-                },
-                "npm-run-path": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-                    "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
-                    "dev": true,
-                    "requires": {
-                        "path-key": "^4.0.0"
-                    }
-                },
-                "onetime": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-                    "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-                    "dev": true,
-                    "requires": {
-                        "mimic-fn": "^4.0.0"
-                    }
-                },
-                "path-key": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-                    "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-                    "dev": true
-                },
-                "strip-final-newline": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-                    "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-                    "dev": true
-                }
-            }
-        },
-        "default-browser-id": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
-            "integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
-            "dev": true,
-            "requires": {
-                "bplist-parser": "^0.2.0",
-                "untildify": "^4.0.0"
-            }
-        },
-        "define-lazy-prop": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
             "dev": true
         },
         "detect-newline": {
@@ -7521,6 +6923,7 @@
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
             "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "esutils": "^2.0.2"
             }
@@ -7562,18 +6965,18 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "escodegen": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
-            "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+            "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
             "dev": true,
             "requires": {
                 "esprima": "^4.0.1",
                 "estraverse": "^5.2.0",
                 "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
                 "source-map": "~0.6.1"
             }
         },
@@ -7582,6 +6985,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
             "integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@eslint/eslintrc": "^1.3.3",
                 "@humanwhocodes/config-array": "^0.11.6",
@@ -7629,6 +7033,7 @@
                     "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
                     "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
                     "dev": true,
+                    "peer": true,
                     "requires": {
                         "esrecurse": "^4.3.0",
                         "estraverse": "^5.2.0"
@@ -7639,6 +7044,7 @@
                     "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
                     "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
                     "dev": true,
+                    "peer": true,
                     "requires": {
                         "deep-is": "^0.1.3",
                         "fast-levenshtein": "^2.0.6",
@@ -7648,23 +7054,6 @@
                         "word-wrap": "^1.2.3"
                     }
                 }
-            }
-        },
-        "eslint-config-prettier": {
-            "version": "8.8.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
-            "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
-            "dev": true,
-            "requires": {}
-        },
-        "eslint-plugin-prettier": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
-            "integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
-            "dev": true,
-            "requires": {
-                "prettier-linter-helpers": "^1.0.0",
-                "synckit": "^0.8.5"
             }
         },
         "eslint-rule-composer": {
@@ -7719,6 +7108,7 @@
             "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
             "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "acorn": "^8.8.0",
                 "acorn-jsx": "^5.3.2",
@@ -7736,6 +7126,7 @@
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
             "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "estraverse": "^5.1.0"
             }
@@ -7807,13 +7198,8 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true
-        },
-        "fast-diff": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-            "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "fast-glob": {
             "version": "3.3.0",
@@ -7849,7 +7235,8 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "fastq": {
             "version": "1.15.0",
@@ -7874,6 +7261,7 @@
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
             "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "flat-cache": "^3.0.4"
             }
@@ -7892,6 +7280,7 @@
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
@@ -7902,6 +7291,7 @@
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
             "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "flatted": "^3.1.0",
                 "rimraf": "^3.0.2"
@@ -7911,7 +7301,8 @@
             "version": "3.2.7",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
             "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -7975,6 +7366,7 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "is-glob": "^4.0.3"
             }
@@ -7984,6 +7376,7 @@
             "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
             "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "type-fest": "^0.20.2"
             }
@@ -8012,7 +7405,8 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
             "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "has": {
             "version": "1.0.3",
@@ -8052,6 +7446,7 @@
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
             "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -8113,12 +7508,6 @@
                 "has": "^1.0.3"
             }
         },
-        "is-docker": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-            "dev": true
-        },
         "is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -8146,15 +7535,6 @@
                 "is-extglob": "^2.1.1"
             }
         },
-        "is-inside-container": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-            "dev": true,
-            "requires": {
-                "is-docker": "^3.0.0"
-            }
-        },
         "is-module": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -8171,30 +7551,14 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
             "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "is-stream": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "dev": true
-        },
-        "is-wsl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-            "dev": true,
-            "requires": {
-                "is-docker": "^2.0.0"
-            },
-            "dependencies": {
-                "is-docker": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-                    "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-                    "dev": true
-                }
-            }
         },
         "isexe": {
             "version": "2.0.0",
@@ -8695,7 +8059,8 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
             "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "js-tokens": {
             "version": "4.0.0",
@@ -8708,6 +8073,7 @@
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
             "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "argparse": "^2.0.1"
             }
@@ -8728,13 +8094,15 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "json5": {
             "version": "2.2.3",
@@ -8759,6 +8127,7 @@
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
@@ -8775,6 +8144,7 @@
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "p-locate": "^5.0.0"
             }
@@ -8789,7 +8159,8 @@
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "lru-cache": {
             "version": "5.1.1",
@@ -8931,59 +8302,6 @@
                 "mimic-fn": "^2.1.0"
             }
         },
-        "open": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
-            "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
-            "dev": true,
-            "requires": {
-                "default-browser": "^4.0.0",
-                "define-lazy-prop": "^3.0.0",
-                "is-inside-container": "^1.0.0",
-                "is-wsl": "^2.2.0"
-            }
-        },
-        "optionator": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-            "dev": true,
-            "requires": {
-                "deep-is": "~0.1.3",
-                "fast-levenshtein": "~2.0.6",
-                "levn": "~0.3.0",
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2",
-                "word-wrap": "~1.2.3"
-            },
-            "dependencies": {
-                "levn": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-                    "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-                    "dev": true,
-                    "requires": {
-                        "prelude-ls": "~1.1.2",
-                        "type-check": "~0.3.2"
-                    }
-                },
-                "prelude-ls": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                    "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-                    "dev": true
-                },
-                "type-check": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                    "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-                    "dev": true,
-                    "requires": {
-                        "prelude-ls": "~1.1.2"
-                    }
-                }
-            }
-        },
         "p-limit": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -8998,6 +8316,7 @@
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "p-limit": "^3.0.2"
             }
@@ -9013,6 +8332,7 @@
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "callsites": "^3.0.0"
             }
@@ -9129,22 +8449,8 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-            "dev": true
-        },
-        "prettier": {
-            "version": "2.8.8",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-            "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-            "dev": true
-        },
-        "prettier-linter-helpers": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-            "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
             "dev": true,
-            "requires": {
-                "fast-diff": "^1.1.2"
-            }
+            "peer": true
         },
         "pretty-format": {
             "version": "29.4.1",
@@ -9179,7 +8485,8 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
             "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "queue-microtask": {
             "version": "1.2.3",
@@ -9237,7 +8544,8 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "resolve.exports": {
             "version": "2.0.0",
@@ -9256,6 +8564,7 @@
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
             "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "glob": "^7.1.3"
             }
@@ -9267,15 +8576,6 @@
             "dev": true,
             "requires": {
                 "fsevents": "~2.3.2"
-            }
-        },
-        "run-applescript": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
-            "integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
-            "dev": true,
-            "requires": {
-                "execa": "^5.0.0"
             }
         },
         "run-parallel": {
@@ -9448,24 +8748,6 @@
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
             "dev": true
         },
-        "synckit": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
-            "integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
-            "dev": true,
-            "requires": {
-                "@pkgr/utils": "^2.3.1",
-                "tslib": "^2.5.0"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.6.0",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-                    "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true
-                }
-            }
-        },
         "terser": {
             "version": "5.16.1",
             "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
@@ -9505,13 +8787,8 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-            "dev": true
-        },
-        "titleize": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
-            "integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "tmpl": {
             "version": "1.0.5",
@@ -9591,6 +8868,7 @@
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "prelude-ls": "^1.2.1"
             }
@@ -9605,34 +8883,13 @@
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "typescript": {
             "version": "4.4.4",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
             "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
-            "dev": true
-        },
-        "typescript-eslint-language-service": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/typescript-eslint-language-service/-/typescript-eslint-language-service-4.1.5.tgz",
-            "integrity": "sha512-lJ9tH53m8e8fYYwhG5hTpiUHCz4SjY55rT8T4ADrmF/29JPdWkUik8cbZy+KsCsUIG1CEMRz+DOV4S+wVyYivQ==",
-            "dev": true,
-            "requires": {}
-        },
-        "typescript-transform-paths": {
-            "version": "3.4.4",
-            "resolved": "https://registry.npmjs.org/typescript-transform-paths/-/typescript-transform-paths-3.4.4.tgz",
-            "integrity": "sha512-b+6JTpJbO9CxVyt9+fIKXpLNUEyzrKXdflsVo/nXbQqelCYkpSsRdI+ikg3SelyE04rUeKlb+Kdt1D8Doa9JoQ==",
-            "dev": true,
-            "requires": {
-                "minimatch": "^3.0.4"
-            }
-        },
-        "untildify": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
-            "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
             "dev": true
         },
         "update-browserslist-db": {
@@ -9650,6 +8907,7 @@
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "punycode": "^2.1.0"
             }
@@ -9701,7 +8959,8 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
             "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "wrap-ansi": {
             "version": "7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,16 +12,11 @@
                 "@mangos/debug": "0.0.9-rc5"
             },
             "devDependencies": {
-                "@babel/core": "7.21.0",
-                "@babel/eslint-parser": "7.19.1",
-                "@babel/eslint-plugin": "7.19.1",
                 "@mangos/jxpath": "1.0.13",
                 "@rollup/plugin-node-resolve": "15.0.1",
                 "@rollup/plugin-terser": "0.1.0",
                 "@types/jest": "29.2.2",
                 "@types/node": "18.11.10",
-                "@typescript-eslint/eslint-plugin": "5.45.1",
-                "@typescript-eslint/parser": "5.45.1",
                 "acorn": "8.11.3",
                 "escodegen": "2.1.0",
                 "jest": "29.3.1",
@@ -112,58 +107,6 @@
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/@babel/eslint-parser": {
-            "version": "7.19.1",
-            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.19.1.tgz",
-            "integrity": "sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==",
-            "dev": true,
-            "dependencies": {
-                "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
-                "eslint-visitor-keys": "^2.1.0",
-                "semver": "^6.3.0"
-            },
-            "engines": {
-                "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-            },
-            "peerDependencies": {
-                "@babel/core": ">=7.11.0",
-                "eslint": "^7.5.0 || ^8.0.0"
-            }
-        },
-        "node_modules/@babel/eslint-parser/node_modules/eslint-visitor-keys": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-            "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@babel/eslint-parser/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/@babel/eslint-plugin": {
-            "version": "7.19.1",
-            "resolved": "https://registry.npmjs.org/@babel/eslint-plugin/-/eslint-plugin-7.19.1.tgz",
-            "integrity": "sha512-ElGPkQPapKMa3zVqXHkZYzuL7I5LbRw9UWBUArgWsdWDDb9XcACqOpBib5tRPA9XvbVZYrFUkoQPbiJ4BFvu4w==",
-            "dev": true,
-            "dependencies": {
-                "eslint-rule-composer": "^0.3.0"
-            },
-            "engines": {
-                "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-            },
-            "peerDependencies": {
-                "@babel/eslint-parser": ">=7.11.0",
-                "eslint": ">=7.5.0"
             }
         },
         "node_modules/@babel/generator": {
@@ -722,66 +665,6 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
-        "node_modules/@eslint/eslintrc": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
-            "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "ajv": "^6.12.4",
-                "debug": "^4.3.2",
-                "espree": "^9.4.0",
-                "globals": "^13.19.0",
-                "ignore": "^5.2.0",
-                "import-fresh": "^3.2.1",
-                "js-yaml": "^4.1.0",
-                "minimatch": "^3.1.2",
-                "strip-json-comments": "^3.1.1"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.8",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
-            "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "@humanwhocodes/object-schema": "^1.2.1",
-                "debug": "^4.1.1",
-                "minimatch": "^3.0.5"
-            },
-            "engines": {
-                "node": ">=10.10.0"
-            }
-        },
-        "node_modules/@humanwhocodes/module-importer": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
-            "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">=12.22"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/nzakas"
-            }
-        },
-        "node_modules/@humanwhocodes/object-schema": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-            "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-            "dev": true,
-            "peer": true
-        },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1256,50 +1139,6 @@
             "integrity": "sha512-u8pM9t5f7KpG5exev9wPl88bhUolJJspjgzZVRiSLM9RZmpJnjlGTN60mu4XS70Vx8c3uT8qLw4fMIdBW3hOmQ==",
             "dev": true
         },
-        "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
-            "version": "5.1.1-v1",
-            "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
-            "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
-            "dev": true,
-            "dependencies": {
-                "eslint-scope": "5.1.1"
-            }
-        },
-        "node_modules/@nodelib/fs.scandir": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-            "dev": true,
-            "dependencies": {
-                "@nodelib/fs.stat": "2.0.5",
-                "run-parallel": "^1.1.9"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@nodelib/fs.stat": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-            "dev": true,
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@nodelib/fs.walk": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-            "dev": true,
-            "dependencies": {
-                "@nodelib/fs.scandir": "2.1.5",
-                "fastq": "^1.6.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
         "node_modules/@rollup/plugin-node-resolve": {
             "version": "15.0.1",
             "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.0.1.tgz",
@@ -1505,12 +1344,6 @@
                 "pretty-format": "^29.0.0"
             }
         },
-        "node_modules/@types/json-schema": {
-            "version": "7.0.11",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-            "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
-            "dev": true
-        },
         "node_modules/@types/node": {
             "version": "18.11.10",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
@@ -1527,12 +1360,6 @@
             "version": "1.20.2",
             "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
             "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
-            "dev": true
-        },
-        "node_modules/@types/semver": {
-            "version": "7.3.13",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-            "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
             "dev": true
         },
         "node_modules/@types/stack-utils": {
@@ -1556,193 +1383,6 @@
             "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
             "dev": true
         },
-        "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "5.45.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.45.1.tgz",
-            "integrity": "sha512-cOizjPlKEh0bXdFrBLTrI/J6B/QMlhwE9auOov53tgB+qMukH6/h8YAK/qw+QJGct/PTbdh2lytGyipxCcEtAw==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/scope-manager": "5.45.1",
-                "@typescript-eslint/type-utils": "5.45.1",
-                "@typescript-eslint/utils": "5.45.1",
-                "debug": "^4.3.4",
-                "ignore": "^5.2.0",
-                "natural-compare-lite": "^1.4.0",
-                "regexpp": "^3.2.0",
-                "semver": "^7.3.7",
-                "tsutils": "^3.21.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "@typescript-eslint/parser": "^5.0.0",
-                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/parser": {
-            "version": "5.45.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.45.1.tgz",
-            "integrity": "sha512-JQ3Ep8bEOXu16q0ztsatp/iQfDCtvap7sp/DKo7DWltUquj5AfCOpX2zSzJ8YkAVnrQNqQ5R62PBz2UtrfmCkA==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/scope-manager": "5.45.1",
-                "@typescript-eslint/types": "5.45.1",
-                "@typescript-eslint/typescript-estree": "5.45.1",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.45.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.45.1.tgz",
-            "integrity": "sha512-D6fCileR6Iai7E35Eb4Kp+k0iW7F1wxXYrOhX/3dywsOJpJAQ20Fwgcf+P/TDtvQ7zcsWsrJaglaQWDhOMsspQ==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "5.45.1",
-                "@typescript-eslint/visitor-keys": "5.45.1"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/type-utils": {
-            "version": "5.45.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.45.1.tgz",
-            "integrity": "sha512-aosxFa+0CoYgYEl3aptLe1svP910DJq68nwEJzyQcrtRhC4BN0tJAvZGAe+D0tzjJmFXe+h4leSsiZhwBa2vrA==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/typescript-estree": "5.45.1",
-                "@typescript-eslint/utils": "5.45.1",
-                "debug": "^4.3.4",
-                "tsutils": "^3.21.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/types": {
-            "version": "5.45.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.45.1.tgz",
-            "integrity": "sha512-HEW3U0E5dLjUT+nk7b4lLbOherS1U4ap+b9pfu2oGsW3oPu7genRaY9dDv3nMczC1rbnRY2W/D7SN05wYoGImg==",
-            "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.45.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.45.1.tgz",
-            "integrity": "sha512-76NZpmpCzWVrrb0XmYEpbwOz/FENBi+5W7ipVXAsG3OoFrQKJMiaqsBMbvGRyLtPotGqUfcY7Ur8j0dksDJDng==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "5.45.1",
-                "@typescript-eslint/visitor-keys": "5.45.1",
-                "debug": "^4.3.4",
-                "globby": "^11.1.0",
-                "is-glob": "^4.0.3",
-                "semver": "^7.3.7",
-                "tsutils": "^3.21.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/utils": {
-            "version": "5.45.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.45.1.tgz",
-            "integrity": "sha512-rlbC5VZz68+yjAzQBc4I7KDYVzWG2X/OrqoZrMahYq3u8FFtmQYc+9rovo/7wlJH5kugJ+jQXV5pJMnofGmPRw==",
-            "dev": true,
-            "dependencies": {
-                "@types/json-schema": "^7.0.9",
-                "@types/semver": "^7.3.12",
-                "@typescript-eslint/scope-manager": "5.45.1",
-                "@typescript-eslint/types": "5.45.1",
-                "@typescript-eslint/typescript-estree": "5.45.1",
-                "eslint-scope": "^5.1.1",
-                "eslint-utils": "^3.0.0",
-                "semver": "^7.3.7"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            }
-        },
-        "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.45.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.45.1.tgz",
-            "integrity": "sha512-cy9ln+6rmthYWjH9fmx+5FU/JDpjQb586++x2FZlveq7GdGuLLW9a2Jcst2TGekH82bXpfmRNSwP9tyEs6RjvQ==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "5.45.1",
-                "eslint-visitor-keys": "^3.3.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
         "node_modules/acorn": {
             "version": "8.11.3",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
@@ -1755,16 +1395,6 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/acorn-jsx": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true,
-            "peer": true,
-            "peerDependencies": {
-                "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            }
-        },
         "node_modules/acorn-walk": {
             "version": "8.2.0",
             "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
@@ -1772,23 +1402,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.4.0"
-            }
-        },
-        "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
             }
         },
         "node_modules/ansi-escapes": {
@@ -1860,22 +1473,6 @@
             "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
             "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
             "dev": true
-        },
-        "node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true,
-            "peer": true
-        },
-        "node_modules/array-union": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/babel-jest": {
             "version": "29.4.1",
@@ -2258,13 +1855,6 @@
             "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
             "dev": true
         },
-        "node_modules/deep-is": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-            "dev": true,
-            "peer": true
-        },
         "node_modules/deepmerge": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
@@ -2299,31 +1889,6 @@
             "dev": true,
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/dir-glob": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-            "dev": true,
-            "dependencies": {
-                "path-type": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/doctrine": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "esutils": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=6.0.0"
             }
         },
         "node_modules/electron-to-chromium": {
@@ -2368,19 +1933,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/escape-string-regexp": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/escodegen": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
@@ -2402,180 +1954,6 @@
                 "source-map": "~0.6.1"
             }
         },
-        "node_modules/eslint": {
-            "version": "8.29.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
-            "integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "@eslint/eslintrc": "^1.3.3",
-                "@humanwhocodes/config-array": "^0.11.6",
-                "@humanwhocodes/module-importer": "^1.0.1",
-                "@nodelib/fs.walk": "^1.2.8",
-                "ajv": "^6.10.0",
-                "chalk": "^4.0.0",
-                "cross-spawn": "^7.0.2",
-                "debug": "^4.3.2",
-                "doctrine": "^3.0.0",
-                "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^7.1.1",
-                "eslint-utils": "^3.0.0",
-                "eslint-visitor-keys": "^3.3.0",
-                "espree": "^9.4.0",
-                "esquery": "^1.4.0",
-                "esutils": "^2.0.2",
-                "fast-deep-equal": "^3.1.3",
-                "file-entry-cache": "^6.0.1",
-                "find-up": "^5.0.0",
-                "glob-parent": "^6.0.2",
-                "globals": "^13.15.0",
-                "grapheme-splitter": "^1.0.4",
-                "ignore": "^5.2.0",
-                "import-fresh": "^3.0.0",
-                "imurmurhash": "^0.1.4",
-                "is-glob": "^4.0.0",
-                "is-path-inside": "^3.0.3",
-                "js-sdsl": "^4.1.4",
-                "js-yaml": "^4.1.0",
-                "json-stable-stringify-without-jsonify": "^1.0.1",
-                "levn": "^0.4.1",
-                "lodash.merge": "^4.6.2",
-                "minimatch": "^3.1.2",
-                "natural-compare": "^1.4.0",
-                "optionator": "^0.9.1",
-                "regexpp": "^3.2.0",
-                "strip-ansi": "^6.0.1",
-                "strip-json-comments": "^3.1.0",
-                "text-table": "^0.2.0"
-            },
-            "bin": {
-                "eslint": "bin/eslint.js"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/eslint-rule-composer": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
-            "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/eslint-scope": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-            "dev": true,
-            "dependencies": {
-                "esrecurse": "^4.3.0",
-                "estraverse": "^4.1.1"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/eslint-scope/node_modules/estraverse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/eslint-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-            "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-            "dev": true,
-            "dependencies": {
-                "eslint-visitor-keys": "^2.0.0"
-            },
-            "engines": {
-                "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/mysticatea"
-            },
-            "peerDependencies": {
-                "eslint": ">=5"
-            }
-        },
-        "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-            "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/eslint-visitor-keys": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-            "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-            "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
-        "node_modules/eslint/node_modules/eslint-scope": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-            "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "esrecurse": "^4.3.0",
-                "estraverse": "^5.2.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
-        "node_modules/eslint/node_modules/optionator": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "deep-is": "^0.1.3",
-                "fast-levenshtein": "^2.0.6",
-                "levn": "^0.4.1",
-                "prelude-ls": "^1.2.1",
-                "type-check": "^0.4.0",
-                "word-wrap": "^1.2.3"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/espree": {
-            "version": "9.4.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-            "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "acorn": "^8.8.0",
-                "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^3.3.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
         "node_modules/esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -2587,31 +1965,6 @@
             },
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/esquery": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-            "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "estraverse": "^5.1.0"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
-        "node_modules/esrecurse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-            "dev": true,
-            "dependencies": {
-                "estraverse": "^5.2.0"
-            },
-            "engines": {
-                "node": ">=4.0"
             }
         },
         "node_modules/estraverse": {
@@ -2686,62 +2039,11 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/fast-deep-equal": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true,
-            "peer": true
-        },
-        "node_modules/fast-glob": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
-            "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
-            "dev": true,
-            "dependencies": {
-                "@nodelib/fs.stat": "^2.0.2",
-                "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.2",
-                "merge2": "^1.3.0",
-                "micromatch": "^4.0.4"
-            },
-            "engines": {
-                "node": ">=8.6.0"
-            }
-        },
-        "node_modules/fast-glob/node_modules/glob-parent": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
-            "dependencies": {
-                "is-glob": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true
-        },
-        "node_modules/fast-levenshtein": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-            "dev": true,
-            "peer": true
-        },
-        "node_modules/fastq": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-            "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
-            "dev": true,
-            "dependencies": {
-                "reusify": "^1.0.4"
-            }
         },
         "node_modules/fb-watchman": {
             "version": "2.0.2",
@@ -2750,19 +2052,6 @@
             "dev": true,
             "dependencies": {
                 "bser": "2.1.1"
-            }
-        },
-        "node_modules/file-entry-cache": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-            "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "flat-cache": "^3.0.4"
-            },
-            "engines": {
-                "node": "^10.12.0 || >=12.0.0"
             }
         },
         "node_modules/fill-range": {
@@ -2776,44 +2065,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/find-up": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "locate-path": "^6.0.0",
-                "path-exists": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/flat-cache": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-            "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "flatted": "^3.1.0",
-                "rimraf": "^3.0.2"
-            },
-            "engines": {
-                "node": "^10.12.0 || >=12.0.0"
-            }
-        },
-        "node_modules/flatted": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-            "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
-            "dev": true,
-            "peer": true
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
@@ -2900,67 +2151,11 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/glob-parent": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "is-glob": "^4.0.3"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
-        "node_modules/globals": {
-            "version": "13.20.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-            "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "type-fest": "^0.20.2"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/globby": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-            "dev": true,
-            "dependencies": {
-                "array-union": "^2.1.0",
-                "dir-glob": "^3.0.1",
-                "fast-glob": "^3.2.9",
-                "ignore": "^5.2.0",
-                "merge2": "^1.4.1",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/graceful-fs": {
             "version": "4.2.10",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
             "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
             "dev": true
-        },
-        "node_modules/grapheme-splitter": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-            "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-            "dev": true,
-            "peer": true
         },
         "node_modules/has": {
             "version": "1.0.3",
@@ -2996,32 +2191,6 @@
             "dev": true,
             "engines": {
                 "node": ">=10.17.0"
-            }
-        },
-        "node_modules/ignore": {
-            "version": "5.2.4",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-            "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
-            "dev": true,
-            "engines": {
-                "node": ">= 4"
-            }
-        },
-        "node_modules/import-fresh": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-            "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "parent-module": "^1.0.0",
-                "resolve-from": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/import-local": {
@@ -3101,15 +2270,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-extglob": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3128,18 +2288,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/is-glob": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
-            "dependencies": {
-                "is-extglob": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/is-module": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -3153,16 +2301,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.12.0"
-            }
-        },
-        "node_modules/is-path-inside": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/is-stream": {
@@ -3817,35 +2955,11 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
-        "node_modules/js-sdsl": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
-            "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
-            "dev": true,
-            "peer": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/js-sdsl"
-            }
-        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true
-        },
-        "node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
         },
         "node_modules/jsesc": {
             "version": "2.5.2",
@@ -3864,20 +2978,6 @@
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true
-        },
-        "node_modules/json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true,
-            "peer": true
-        },
-        "node_modules/json-stable-stringify-without-jsonify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-            "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-            "dev": true,
-            "peer": true
         },
         "node_modules/json5": {
             "version": "2.2.3",
@@ -3909,54 +3009,17 @@
                 "node": ">=6"
             }
         },
-        "node_modules/levn": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "prelude-ls": "^1.2.1",
-                "type-check": "~0.4.0"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
         "node_modules/lines-and-columns": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "dev": true
         },
-        "node_modules/locate-path": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "p-locate": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
             "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
             "dev": true
-        },
-        "node_modules/lodash.merge": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true,
-            "peer": true
         },
         "node_modules/lru-cache": {
             "version": "5.1.1",
@@ -4012,15 +3075,6 @@
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "dev": true
         },
-        "node_modules/merge2": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 8"
-            }
-        },
         "node_modules/micromatch": {
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -4067,12 +3121,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-            "dev": true
-        },
-        "node_modules/natural-compare-lite": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-            "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
             "dev": true
         },
         "node_modules/node-int64": {
@@ -4147,40 +3195,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/p-locate": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "p-limit": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/p-try": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/parent-module": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "callsites": "^3.0.0"
-            },
             "engines": {
                 "node": ">=6"
             }
@@ -4235,15 +3254,6 @@
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true
-        },
-        "node_modules/path-type": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/picocolors": {
             "version": "1.0.0",
@@ -4336,16 +3346,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/prelude-ls": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
         "node_modules/pretty-format": {
             "version": "29.4.1",
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.4.1.tgz",
@@ -4385,53 +3385,11 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/punycode": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-            "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/queue-microtask": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
-        },
         "node_modules/react-is": {
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
             "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
             "dev": true
-        },
-        "node_modules/regexpp": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-            "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/mysticatea"
-            }
         },
         "node_modules/require-directory": {
             "version": "2.1.1",
@@ -4480,16 +3438,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/resolve-from": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/resolve.exports": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.0.tgz",
@@ -4497,32 +3445,6 @@
             "dev": true,
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/reusify": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-            "dev": true,
-            "engines": {
-                "iojs": ">=1.0.0",
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/rollup": {
@@ -4539,29 +3461,6 @@
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
-            }
-        },
-        "node_modules/run-parallel": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "dependencies": {
-                "queue-microtask": "^1.2.2"
             }
         },
         "node_modules/semver": {
@@ -4820,13 +3719,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/text-table": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-            "dev": true,
-            "peer": true
-        },
         "node_modules/tmpl": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -4940,40 +3832,6 @@
                 }
             }
         },
-        "node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
-        },
-        "node_modules/tsutils": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-            "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-            "dev": true,
-            "dependencies": {
-                "tslib": "^1.8.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            },
-            "peerDependencies": {
-                "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-            }
-        },
-        "node_modules/type-check": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "prelude-ls": "^1.2.1"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
         "node_modules/type-detect": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -4981,19 +3839,6 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/typescript": {
@@ -5033,16 +3878,6 @@
             },
             "peerDependencies": {
                 "browserslist": ">= 4.21.0"
-            }
-        },
-        "node_modules/uri-js": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "punycode": "^2.1.0"
             }
         },
         "node_modules/v8-compile-cache-lib": {
@@ -5093,16 +3928,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/wrap-ansi": {
@@ -5266,40 +4091,6 @@
                     "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
                     "dev": true
                 }
-            }
-        },
-        "@babel/eslint-parser": {
-            "version": "7.19.1",
-            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.19.1.tgz",
-            "integrity": "sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==",
-            "dev": true,
-            "requires": {
-                "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
-                "eslint-visitor-keys": "^2.1.0",
-                "semver": "^6.3.0"
-            },
-            "dependencies": {
-                "eslint-visitor-keys": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-                    "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-                    "dev": true
-                },
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
-                }
-            }
-        },
-        "@babel/eslint-plugin": {
-            "version": "7.19.1",
-            "resolved": "https://registry.npmjs.org/@babel/eslint-plugin/-/eslint-plugin-7.19.1.tgz",
-            "integrity": "sha512-ElGPkQPapKMa3zVqXHkZYzuL7I5LbRw9UWBUArgWsdWDDb9XcACqOpBib5tRPA9XvbVZYrFUkoQPbiJ4BFvu4w==",
-            "dev": true,
-            "requires": {
-                "eslint-rule-composer": "^0.3.0"
             }
         },
         "@babel/generator": {
@@ -5727,50 +4518,6 @@
                 }
             }
         },
-        "@eslint/eslintrc": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
-            "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "ajv": "^6.12.4",
-                "debug": "^4.3.2",
-                "espree": "^9.4.0",
-                "globals": "^13.19.0",
-                "ignore": "^5.2.0",
-                "import-fresh": "^3.2.1",
-                "js-yaml": "^4.1.0",
-                "minimatch": "^3.1.2",
-                "strip-json-comments": "^3.1.1"
-            }
-        },
-        "@humanwhocodes/config-array": {
-            "version": "0.11.8",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
-            "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "@humanwhocodes/object-schema": "^1.2.1",
-                "debug": "^4.1.1",
-                "minimatch": "^3.0.5"
-            }
-        },
-        "@humanwhocodes/module-importer": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
-            "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-            "dev": true,
-            "peer": true
-        },
-        "@humanwhocodes/object-schema": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-            "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-            "dev": true,
-            "peer": true
-        },
         "@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -6149,41 +4896,6 @@
             "integrity": "sha512-u8pM9t5f7KpG5exev9wPl88bhUolJJspjgzZVRiSLM9RZmpJnjlGTN60mu4XS70Vx8c3uT8qLw4fMIdBW3hOmQ==",
             "dev": true
         },
-        "@nicolo-ribaudo/eslint-scope-5-internals": {
-            "version": "5.1.1-v1",
-            "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
-            "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
-            "dev": true,
-            "requires": {
-                "eslint-scope": "5.1.1"
-            }
-        },
-        "@nodelib/fs.scandir": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-            "dev": true,
-            "requires": {
-                "@nodelib/fs.stat": "2.0.5",
-                "run-parallel": "^1.1.9"
-            }
-        },
-        "@nodelib/fs.stat": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-            "dev": true
-        },
-        "@nodelib/fs.walk": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-            "dev": true,
-            "requires": {
-                "@nodelib/fs.scandir": "2.1.5",
-                "fastq": "^1.6.0"
-            }
-        },
         "@rollup/plugin-node-resolve": {
             "version": "15.0.1",
             "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.0.1.tgz",
@@ -6356,12 +5068,6 @@
                 "pretty-format": "^29.0.0"
             }
         },
-        "@types/json-schema": {
-            "version": "7.0.11",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-            "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
-            "dev": true
-        },
         "@types/node": {
             "version": "18.11.10",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
@@ -6378,12 +5084,6 @@
             "version": "1.20.2",
             "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
             "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
-            "dev": true
-        },
-        "@types/semver": {
-            "version": "7.3.13",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-            "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
             "dev": true
         },
         "@types/stack-utils": {
@@ -6407,136 +5107,17 @@
             "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
             "dev": true
         },
-        "@typescript-eslint/eslint-plugin": {
-            "version": "5.45.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.45.1.tgz",
-            "integrity": "sha512-cOizjPlKEh0bXdFrBLTrI/J6B/QMlhwE9auOov53tgB+qMukH6/h8YAK/qw+QJGct/PTbdh2lytGyipxCcEtAw==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/scope-manager": "5.45.1",
-                "@typescript-eslint/type-utils": "5.45.1",
-                "@typescript-eslint/utils": "5.45.1",
-                "debug": "^4.3.4",
-                "ignore": "^5.2.0",
-                "natural-compare-lite": "^1.4.0",
-                "regexpp": "^3.2.0",
-                "semver": "^7.3.7",
-                "tsutils": "^3.21.0"
-            }
-        },
-        "@typescript-eslint/parser": {
-            "version": "5.45.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.45.1.tgz",
-            "integrity": "sha512-JQ3Ep8bEOXu16q0ztsatp/iQfDCtvap7sp/DKo7DWltUquj5AfCOpX2zSzJ8YkAVnrQNqQ5R62PBz2UtrfmCkA==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/scope-manager": "5.45.1",
-                "@typescript-eslint/types": "5.45.1",
-                "@typescript-eslint/typescript-estree": "5.45.1",
-                "debug": "^4.3.4"
-            }
-        },
-        "@typescript-eslint/scope-manager": {
-            "version": "5.45.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.45.1.tgz",
-            "integrity": "sha512-D6fCileR6Iai7E35Eb4Kp+k0iW7F1wxXYrOhX/3dywsOJpJAQ20Fwgcf+P/TDtvQ7zcsWsrJaglaQWDhOMsspQ==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/types": "5.45.1",
-                "@typescript-eslint/visitor-keys": "5.45.1"
-            }
-        },
-        "@typescript-eslint/type-utils": {
-            "version": "5.45.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.45.1.tgz",
-            "integrity": "sha512-aosxFa+0CoYgYEl3aptLe1svP910DJq68nwEJzyQcrtRhC4BN0tJAvZGAe+D0tzjJmFXe+h4leSsiZhwBa2vrA==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/typescript-estree": "5.45.1",
-                "@typescript-eslint/utils": "5.45.1",
-                "debug": "^4.3.4",
-                "tsutils": "^3.21.0"
-            }
-        },
-        "@typescript-eslint/types": {
-            "version": "5.45.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.45.1.tgz",
-            "integrity": "sha512-HEW3U0E5dLjUT+nk7b4lLbOherS1U4ap+b9pfu2oGsW3oPu7genRaY9dDv3nMczC1rbnRY2W/D7SN05wYoGImg==",
-            "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-            "version": "5.45.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.45.1.tgz",
-            "integrity": "sha512-76NZpmpCzWVrrb0XmYEpbwOz/FENBi+5W7ipVXAsG3OoFrQKJMiaqsBMbvGRyLtPotGqUfcY7Ur8j0dksDJDng==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/types": "5.45.1",
-                "@typescript-eslint/visitor-keys": "5.45.1",
-                "debug": "^4.3.4",
-                "globby": "^11.1.0",
-                "is-glob": "^4.0.3",
-                "semver": "^7.3.7",
-                "tsutils": "^3.21.0"
-            }
-        },
-        "@typescript-eslint/utils": {
-            "version": "5.45.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.45.1.tgz",
-            "integrity": "sha512-rlbC5VZz68+yjAzQBc4I7KDYVzWG2X/OrqoZrMahYq3u8FFtmQYc+9rovo/7wlJH5kugJ+jQXV5pJMnofGmPRw==",
-            "dev": true,
-            "requires": {
-                "@types/json-schema": "^7.0.9",
-                "@types/semver": "^7.3.12",
-                "@typescript-eslint/scope-manager": "5.45.1",
-                "@typescript-eslint/types": "5.45.1",
-                "@typescript-eslint/typescript-estree": "5.45.1",
-                "eslint-scope": "^5.1.1",
-                "eslint-utils": "^3.0.0",
-                "semver": "^7.3.7"
-            }
-        },
-        "@typescript-eslint/visitor-keys": {
-            "version": "5.45.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.45.1.tgz",
-            "integrity": "sha512-cy9ln+6rmthYWjH9fmx+5FU/JDpjQb586++x2FZlveq7GdGuLLW9a2Jcst2TGekH82bXpfmRNSwP9tyEs6RjvQ==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/types": "5.45.1",
-                "eslint-visitor-keys": "^3.3.0"
-            }
-        },
         "acorn": {
             "version": "8.11.3",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
             "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "dev": true
         },
-        "acorn-jsx": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true,
-            "peer": true,
-            "requires": {}
-        },
         "acorn-walk": {
             "version": "8.2.0",
             "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
             "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
             "dev": true
-        },
-        "ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-            }
         },
         "ansi-escapes": {
             "version": "4.3.2",
@@ -6584,19 +5165,6 @@
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
             "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-            "dev": true
-        },
-        "argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true,
-            "peer": true
-        },
-        "array-union": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
             "dev": true
         },
         "babel-jest": {
@@ -6878,13 +5446,6 @@
             "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
             "dev": true
         },
-        "deep-is": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-            "dev": true,
-            "peer": true
-        },
         "deepmerge": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
@@ -6908,25 +5469,6 @@
             "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.3.1.tgz",
             "integrity": "sha512-hlM3QR272NXCi4pq+N4Kok4kOp6EsgOM3ZSpJI7Da3UAs+Ttsi8MRmB6trM/lhyzUxGfOgnpkHtgqm5Q/CTcfQ==",
             "dev": true
-        },
-        "dir-glob": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-            "dev": true,
-            "requires": {
-                "path-type": "^4.0.0"
-            }
-        },
-        "doctrine": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "esutils": "^2.0.2"
-            }
         },
         "electron-to-chromium": {
             "version": "1.4.284",
@@ -6961,13 +5503,6 @@
             "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
             "dev": true
         },
-        "escape-string-regexp": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-            "dev": true,
-            "peer": true
-        },
         "escodegen": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
@@ -6980,165 +5515,11 @@
                 "source-map": "~0.6.1"
             }
         },
-        "eslint": {
-            "version": "8.29.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
-            "integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "@eslint/eslintrc": "^1.3.3",
-                "@humanwhocodes/config-array": "^0.11.6",
-                "@humanwhocodes/module-importer": "^1.0.1",
-                "@nodelib/fs.walk": "^1.2.8",
-                "ajv": "^6.10.0",
-                "chalk": "^4.0.0",
-                "cross-spawn": "^7.0.2",
-                "debug": "^4.3.2",
-                "doctrine": "^3.0.0",
-                "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^7.1.1",
-                "eslint-utils": "^3.0.0",
-                "eslint-visitor-keys": "^3.3.0",
-                "espree": "^9.4.0",
-                "esquery": "^1.4.0",
-                "esutils": "^2.0.2",
-                "fast-deep-equal": "^3.1.3",
-                "file-entry-cache": "^6.0.1",
-                "find-up": "^5.0.0",
-                "glob-parent": "^6.0.2",
-                "globals": "^13.15.0",
-                "grapheme-splitter": "^1.0.4",
-                "ignore": "^5.2.0",
-                "import-fresh": "^3.0.0",
-                "imurmurhash": "^0.1.4",
-                "is-glob": "^4.0.0",
-                "is-path-inside": "^3.0.3",
-                "js-sdsl": "^4.1.4",
-                "js-yaml": "^4.1.0",
-                "json-stable-stringify-without-jsonify": "^1.0.1",
-                "levn": "^0.4.1",
-                "lodash.merge": "^4.6.2",
-                "minimatch": "^3.1.2",
-                "natural-compare": "^1.4.0",
-                "optionator": "^0.9.1",
-                "regexpp": "^3.2.0",
-                "strip-ansi": "^6.0.1",
-                "strip-json-comments": "^3.1.0",
-                "text-table": "^0.2.0"
-            },
-            "dependencies": {
-                "eslint-scope": {
-                    "version": "7.1.1",
-                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-                    "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-                    "dev": true,
-                    "peer": true,
-                    "requires": {
-                        "esrecurse": "^4.3.0",
-                        "estraverse": "^5.2.0"
-                    }
-                },
-                "optionator": {
-                    "version": "0.9.1",
-                    "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-                    "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-                    "dev": true,
-                    "peer": true,
-                    "requires": {
-                        "deep-is": "^0.1.3",
-                        "fast-levenshtein": "^2.0.6",
-                        "levn": "^0.4.1",
-                        "prelude-ls": "^1.2.1",
-                        "type-check": "^0.4.0",
-                        "word-wrap": "^1.2.3"
-                    }
-                }
-            }
-        },
-        "eslint-rule-composer": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
-            "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
-            "dev": true
-        },
-        "eslint-scope": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-            "dev": true,
-            "requires": {
-                "esrecurse": "^4.3.0",
-                "estraverse": "^4.1.1"
-            },
-            "dependencies": {
-                "estraverse": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-                    "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-                    "dev": true
-                }
-            }
-        },
-        "eslint-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-            "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-            "dev": true,
-            "requires": {
-                "eslint-visitor-keys": "^2.0.0"
-            },
-            "dependencies": {
-                "eslint-visitor-keys": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-                    "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-                    "dev": true
-                }
-            }
-        },
-        "eslint-visitor-keys": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-            "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-            "dev": true
-        },
-        "espree": {
-            "version": "9.4.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-            "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "acorn": "^8.8.0",
-                "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^3.3.0"
-            }
-        },
         "esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
             "dev": true
-        },
-        "esquery": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-            "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "estraverse": "^5.1.0"
-            }
-        },
-        "esrecurse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-            "dev": true,
-            "requires": {
-                "estraverse": "^5.2.0"
-            }
         },
         "estraverse": {
             "version": "5.3.0",
@@ -7194,58 +5575,11 @@
                 "jest-util": "^29.4.1"
             }
         },
-        "fast-deep-equal": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true,
-            "peer": true
-        },
-        "fast-glob": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
-            "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
-            "dev": true,
-            "requires": {
-                "@nodelib/fs.stat": "^2.0.2",
-                "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.2",
-                "merge2": "^1.3.0",
-                "micromatch": "^4.0.4"
-            },
-            "dependencies": {
-                "glob-parent": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-                    "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "^4.0.1"
-                    }
-                }
-            }
-        },
         "fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true
-        },
-        "fast-levenshtein": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-            "dev": true,
-            "peer": true
-        },
-        "fastq": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-            "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
-            "dev": true,
-            "requires": {
-                "reusify": "^1.0.4"
-            }
         },
         "fb-watchman": {
             "version": "2.0.2",
@@ -7256,16 +5590,6 @@
                 "bser": "2.1.1"
             }
         },
-        "file-entry-cache": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-            "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "flat-cache": "^3.0.4"
-            }
-        },
         "fill-range": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -7274,35 +5598,6 @@
             "requires": {
                 "to-regex-range": "^5.0.1"
             }
-        },
-        "find-up": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "locate-path": "^6.0.0",
-                "path-exists": "^4.0.0"
-            }
-        },
-        "flat-cache": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-            "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "flatted": "^3.1.0",
-                "rimraf": "^3.0.2"
-            }
-        },
-        "flatted": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-            "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
-            "dev": true,
-            "peer": true
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -7361,52 +5656,11 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
-        "glob-parent": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "is-glob": "^4.0.3"
-            }
-        },
-        "globals": {
-            "version": "13.20.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-            "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "type-fest": "^0.20.2"
-            }
-        },
-        "globby": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-            "dev": true,
-            "requires": {
-                "array-union": "^2.1.0",
-                "dir-glob": "^3.0.1",
-                "fast-glob": "^3.2.9",
-                "ignore": "^5.2.0",
-                "merge2": "^1.4.1",
-                "slash": "^3.0.0"
-            }
-        },
         "graceful-fs": {
             "version": "4.2.10",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
             "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
             "dev": true
-        },
-        "grapheme-splitter": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-            "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-            "dev": true,
-            "peer": true
         },
         "has": {
             "version": "1.0.3",
@@ -7434,23 +5688,6 @@
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "dev": true
-        },
-        "ignore": {
-            "version": "5.2.4",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-            "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
-            "dev": true
-        },
-        "import-fresh": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-            "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "parent-module": "^1.0.0",
-                "resolve-from": "^4.0.0"
-            }
         },
         "import-local": {
             "version": "3.1.0",
@@ -7508,12 +5745,6 @@
                 "has": "^1.0.3"
             }
         },
-        "is-extglob": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "dev": true
-        },
         "is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -7526,15 +5757,6 @@
             "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
             "dev": true
         },
-        "is-glob": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
-            "requires": {
-                "is-extglob": "^2.1.1"
-            }
-        },
         "is-module": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -7546,13 +5768,6 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true
-        },
-        "is-path-inside": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-            "dev": true,
-            "peer": true
         },
         "is-stream": {
             "version": "2.0.1",
@@ -8055,28 +6270,11 @@
                 }
             }
         },
-        "js-sdsl": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
-            "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
-            "dev": true,
-            "peer": true
-        },
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true
-        },
-        "js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "argparse": "^2.0.1"
-            }
         },
         "jsesc": {
             "version": "2.5.2",
@@ -8089,20 +6287,6 @@
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true
-        },
-        "json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true,
-            "peer": true
-        },
-        "json-stable-stringify-without-jsonify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-            "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-            "dev": true,
-            "peer": true
         },
         "json5": {
             "version": "2.2.3",
@@ -8122,45 +6306,17 @@
             "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
             "dev": true
         },
-        "levn": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "prelude-ls": "^1.2.1",
-                "type-check": "~0.4.0"
-            }
-        },
         "lines-and-columns": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "dev": true
         },
-        "locate-path": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "p-locate": "^5.0.0"
-            }
-        },
         "lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
             "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
             "dev": true
-        },
-        "lodash.merge": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true,
-            "peer": true
         },
         "lru-cache": {
             "version": "5.1.1",
@@ -8209,12 +6365,6 @@
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "dev": true
         },
-        "merge2": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true
-        },
         "micromatch": {
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -8249,12 +6399,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-            "dev": true
-        },
-        "natural-compare-lite": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-            "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
             "dev": true
         },
         "node-int64": {
@@ -8311,31 +6455,11 @@
                 "yocto-queue": "^0.1.0"
             }
         },
-        "p-locate": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "p-limit": "^3.0.2"
-            }
-        },
         "p-try": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "dev": true
-        },
-        "parent-module": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "callsites": "^3.0.0"
-            }
         },
         "parse-json": {
             "version": "5.2.0",
@@ -8371,12 +6495,6 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "dev": true
-        },
-        "path-type": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
             "dev": true
         },
         "picocolors": {
@@ -8445,13 +6563,6 @@
                 }
             }
         },
-        "prelude-ls": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-            "dev": true,
-            "peer": true
-        },
         "pretty-format": {
             "version": "29.4.1",
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.4.1.tgz",
@@ -8481,29 +6592,10 @@
                 "sisteransi": "^1.0.5"
             }
         },
-        "punycode": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-            "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-            "dev": true,
-            "peer": true
-        },
-        "queue-microtask": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-            "dev": true
-        },
         "react-is": {
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
             "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-            "dev": true
-        },
-        "regexpp": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-            "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
             "dev": true
         },
         "require-directory": {
@@ -8540,34 +6632,11 @@
                 }
             }
         },
-        "resolve-from": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-            "dev": true,
-            "peer": true
-        },
         "resolve.exports": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.0.tgz",
             "integrity": "sha512-6K/gDlqgQscOlg9fSRpWstA8sYe8rbELsSTNpx+3kTrsVCzvSl0zIvRErM7fdl9ERWDsKnrLnwB+Ne89918XOg==",
             "dev": true
-        },
-        "reusify": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-            "dev": true
-        },
-        "rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "glob": "^7.1.3"
-            }
         },
         "rollup": {
             "version": "3.6.0",
@@ -8576,15 +6645,6 @@
             "dev": true,
             "requires": {
                 "fsevents": "~2.3.2"
-            }
-        },
-        "run-parallel": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-            "dev": true,
-            "requires": {
-                "queue-microtask": "^1.2.2"
             }
         },
         "semver": {
@@ -8783,13 +6843,6 @@
                 "minimatch": "^3.0.4"
             }
         },
-        "text-table": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-            "dev": true,
-            "peer": true
-        },
         "tmpl": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -8848,43 +6901,11 @@
                 "yn": "3.1.1"
             }
         },
-        "tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
-        },
-        "tsutils": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-            "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-            "dev": true,
-            "requires": {
-                "tslib": "^1.8.1"
-            }
-        },
-        "type-check": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "prelude-ls": "^1.2.1"
-            }
-        },
         "type-detect": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
             "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
             "dev": true
-        },
-        "type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "dev": true,
-            "peer": true
         },
         "typescript": {
             "version": "4.5.2",
@@ -8900,16 +6921,6 @@
             "requires": {
                 "escalade": "^3.1.1",
                 "picocolors": "^1.0.0"
-            }
-        },
-        "uri-js": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "punycode": "^2.1.0"
             }
         },
         "v8-compile-cache-lib": {
@@ -8954,13 +6965,6 @@
             "requires": {
                 "isexe": "^2.0.0"
             }
-        },
-        "word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-            "dev": true,
-            "peer": true
         },
         "wrap-ansi": {
             "version": "7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
                 "rollup": "3.6.0",
                 "ts-jest": "29.0.3",
                 "ts-node": "10.9.1",
-                "typescript": "4.4.4"
+                "typescript": "4.5.2"
             },
             "engines": {
                 "node": ">=v16.18.1"
@@ -4997,9 +4997,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.4.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-            "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
+            "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -8887,9 +8887,9 @@
             "peer": true
         },
         "typescript": {
-            "version": "4.4.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-            "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
+            "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
             "dev": true
         },
         "update-browserslist-db": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lib-r-math.js",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "lib-r-math.js",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "license": "SEE LICENSE IN LICENSE.txt",
             "dependencies": {
                 "@mangos/debug": "0.0.9-rc5"
@@ -23,7 +23,6 @@
                 "ms": "3.0.0-canary.1",
                 "rollup": "3.6.0",
                 "ts-jest": "29.0.3",
-                "ts-node": "10.9.1",
                 "typescript": "4.5.2"
             },
             "engines": {
@@ -648,6 +647,8 @@
             "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
             "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
             "dev": true,
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "0.3.9"
             },
@@ -660,6 +661,8 @@
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
             "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
             "dev": true,
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -1234,25 +1237,33 @@
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
             "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "node_modules/@tsconfig/node12": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
             "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "node_modules/@tsconfig/node14": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
             "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "node_modules/@tsconfig/node16": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
             "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.0",
@@ -1400,6 +1411,8 @@
             "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
             "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
             "dev": true,
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -1472,7 +1485,9 @@
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
             "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "node_modules/babel-jest": {
             "version": "29.4.1",
@@ -1810,7 +1825,9 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
             "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
@@ -1878,6 +1895,8 @@
             "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
             "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
             "dev": true,
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.3.1"
             }
@@ -3794,6 +3813,8 @@
             "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
             "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
             "dev": true,
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -3884,7 +3905,9 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
             "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "node_modules/v8-to-istanbul": {
             "version": "9.0.1",
@@ -4013,6 +4036,8 @@
             "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
             "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
             "dev": true,
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -4502,6 +4527,8 @@
             "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
             "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
             "dev": true,
+            "optional": true,
+            "peer": true,
             "requires": {
                 "@jridgewell/trace-mapping": "0.3.9"
             },
@@ -4511,6 +4538,8 @@
                     "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
                     "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
                     "dev": true,
+                    "optional": true,
+                    "peer": true,
                     "requires": {
                         "@jridgewell/resolve-uri": "^3.0.3",
                         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -4958,25 +4987,33 @@
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
             "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "@tsconfig/node12": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
             "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "@tsconfig/node14": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
             "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "@tsconfig/node16": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
             "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "@types/babel__core": {
             "version": "7.20.0",
@@ -5117,7 +5154,9 @@
             "version": "8.2.0",
             "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
             "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "ansi-escapes": {
             "version": "4.3.2",
@@ -5165,7 +5204,9 @@
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
             "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "babel-jest": {
             "version": "29.4.1",
@@ -5410,7 +5451,9 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
             "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "cross-spawn": {
             "version": "7.0.3",
@@ -5462,7 +5505,9 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
             "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "diff-sequences": {
             "version": "29.3.1",
@@ -6885,6 +6930,8 @@
             "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
             "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
             "dev": true,
+            "optional": true,
+            "peer": true,
             "requires": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -6927,7 +6974,9 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
             "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "v8-to-istanbul": {
             "version": "9.0.1",
@@ -7030,7 +7079,9 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
             "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "yocto-queue": {
             "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     ],
     "scripts": {
         "xprebuild": "npm run lint",
-        "build": "node --trace-warnings scripts/build-copy.mjs",
+        "build": "node --trace-warnings scripts/build.mjs",
         "xpostbuild": "node --trace-warnings scripts/rollup.build.mjs",
         "lint": "eslint-config-prettier .eslintrc.cjs jest.config.cjs scripts/*.mjs  src/**/*.ts",
         "lint:fix": "npm run lint -- --fix",
@@ -108,7 +108,7 @@
         "rollup": "3.6.0",
         "ts-jest": "29.0.3",
         "ts-node": "10.9.1",
-        "typescript": "4.4.4"
+        "typescript": "4.5.2"
     },
     "engines": {
         "node": ">=v16.18.1"

--- a/package.json
+++ b/package.json
@@ -78,29 +78,20 @@
         "README.md"
     ],
     "scripts": {
-        "xprebuild": "npm run lint",
         "build": "node --trace-warnings scripts/build.mjs",
         "xpostbuild": "node --trace-warnings scripts/rollup.build.mjs",
-        "lint": "eslint-config-prettier .eslintrc.cjs jest.config.cjs scripts/*.mjs  src/**/*.ts",
-        "lint:fix": "npm run lint -- --fix",
         "prepublishOnly": "npm run build",
-        "test": "jest --verbose",
-        "pretty": "prettier -w ."
+        "test": "jest --verbose"
     },
     "dependencies": {
         "@mangos/debug": "0.0.9-rc5"
     },
     "devDependencies": {
-        "@babel/core": "7.21.0",
-        "@babel/eslint-parser": "7.19.1",
-        "@babel/eslint-plugin": "7.19.1",
         "@mangos/jxpath": "1.0.13",
         "@rollup/plugin-node-resolve": "15.0.1",
         "@rollup/plugin-terser": "0.1.0",
         "@types/jest": "29.2.2",
         "@types/node": "18.11.10",
-        "@typescript-eslint/eslint-plugin": "5.45.1",
-        "@typescript-eslint/parser": "5.45.1",
         "acorn": "8.11.3",
         "escodegen": "2.1.0",
         "jest": "29.3.1",

--- a/package.json
+++ b/package.json
@@ -87,13 +87,6 @@
         "test": "jest --verbose",
         "pretty": "prettier -w ."
     },
-    "contributes": {
-        "typescriptServerPlugins": [
-            {
-                "name": "typescript-eslint-language-service"
-            }
-        ]
-    },
     "dependencies": {
         "@mangos/debug": "0.0.9-rc5"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lib-r-math.js",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Javascript Implementation of Statistical R standalone library rnmath",
     "keywords": [
         "statistics",
@@ -65,7 +65,8 @@
     "type": "module",
     "exports": {
         "import": "./dist/esm/index.mjs",
-        "require": "./dist/commonjs/index.cjs"
+        "require": "./dist/commonjs/index.cjs",
+        "types": "./dist/types/index.d.ts"
     },
     "browser": "./dist/web.esm.mjs",
     "types": "./dist/types/index.d.ts",
@@ -79,7 +80,7 @@
     ],
     "scripts": {
         "build": "node --trace-warnings scripts/build.mjs",
-        "xpostbuild": "node --trace-warnings scripts/rollup.build.mjs",
+        "postbuild": "node --trace-warnings scripts/rollup.build.mjs",
         "prepublishOnly": "npm run build",
         "test": "jest --verbose"
     },
@@ -98,10 +99,9 @@
         "ms": "3.0.0-canary.1",
         "rollup": "3.6.0",
         "ts-jest": "29.0.3",
-        "ts-node": "10.9.1",
         "typescript": "4.5.2"
     },
     "engines": {
-        "node": ">=v16.18.1"
+        "node": ">=v20.4.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -78,9 +78,9 @@
         "README.md"
     ],
     "scripts": {
-        "prebuild": "npm run lint",
-        "build": "node --trace-warnings scripts/build.mjs",
-        "postbuild": "node --trace-warnings scripts/rollup.build.mjs",
+        "xprebuild": "npm run lint",
+        "build": "node --trace-warnings scripts/build-copy.mjs",
+        "xpostbuild": "node --trace-warnings scripts/rollup.build.mjs",
         "lint": "eslint-config-prettier .eslintrc.cjs jest.config.cjs scripts/*.mjs  src/**/*.ts",
         "lint:fix": "npm run lint -- --fix",
         "prepublishOnly": "npm run build",
@@ -108,20 +108,14 @@
         "@types/node": "18.11.10",
         "@typescript-eslint/eslint-plugin": "5.45.1",
         "@typescript-eslint/parser": "5.45.1",
-        "acorn": "8.8.1",
-        "escodegen": "2.0.0",
-        "eslint": "8.29.0",
-        "eslint-config-prettier": "8.8.0",
-        "eslint-plugin-prettier": "5.0.0",
+        "acorn": "8.11.3",
+        "escodegen": "2.1.0",
         "jest": "29.3.1",
         "ms": "3.0.0-canary.1",
-        "prettier": "2.8.8",
         "rollup": "3.6.0",
         "ts-jest": "29.0.3",
         "ts-node": "10.9.1",
-        "typescript": "4.4.4",
-        "typescript-eslint-language-service": "4.1.5",
-        "typescript-transform-paths": "3.4.4"
+        "typescript": "4.4.4"
     },
     "engines": {
         "node": ">=v16.18.1"

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 // @ts-check4785838a-0a9e-41fa-a217-4bd234c00c9e
 
+// TODO: resolve paths like described here
+// https://www.typescriptlang.org/docs/handbook/modules/reference.html#paths
+
+
 import { readdirSync, lstatSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import { writeFileSync } from 'node:fs';

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// @ts-check
+// @ts-check4785838a-0a9e-41fa-a217-4bd234c00c9e
 
 import { readdirSync, lstatSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
@@ -10,141 +10,19 @@ import { parse } from 'acorn';
 import jxpath from '@mangos/jxpath';
 import { generate } from 'escodegen';
 
-const DIR = './dist';
-const DIR_COMMONJS = './dist/commonjs';
-const DIR_ESM = './dist/esm';
-
-// Delete and recreate the output directory.
-try {
-    rmSync(DIR, { recursive: true });
-} catch (error) {
-    if (error.code !== 'ENOENT') throw error;
+function removeSafeDir(dir) {
+    try {
+        rmSync(dir, { recursive: true });
+    } catch (error) {
+        if (error.code !== 'ENOENT') throw error;
+    }
 }
-mkdirSync(DIR_COMMONJS, { recursive: true });
-mkdirSync(DIR_ESM, { recursive: true });
-// Read the TypeScript config file.
-const { config } = ts.readConfigFile('tsconfig.json', (fileName) => readFileSync(fileName).toString());
-
-const sourceDir = join('src');
 
 function getAllRootSourceFiles() {
     let sourceFiles = ['./index.ts'];
     return sourceFiles.map((f) => join('src', f));
 }
-// Build CommonJS module.
-compile(getAllRootSourceFiles(), DIR_COMMONJS, {
-    module: ts.ModuleKind.CommonJS,
-    moduleResolution: ts.ModuleResolutionKind.NodeJs,
-    declaration: false,
-    outDir: undefined, // this is a must!
-    declarationMap: false,
-    removeComments: true,
-    sourceMap: false,
-    importHelpers: false // commonjs sometimes needs some extra code to create analogs for esm constructs (example export * from 'xyz)
-});
 
-// Build an ES2015 module and type declarations.
-
-compile(getAllRootSourceFiles(), DIR_ESM, {
-    module: ts.ModuleKind.ES2020,
-    moduleResolution: ts.ModuleResolutionKind.NodeJs,
-    declaration: true,
-    declarationDir: './types', // this becomes ./dist/types
-    declarationMap: false,
-    removeComments: true,
-    sourceMap: false,
-    importHelpers: false,
-    outDir: undefined
-});
-
-/**
- * Compiles files to JavaScript.
- *
- * @param {string[]} files
- * @param {ts.CompilerOptions} options
- */
-function compile(files, targetDIR, options) {
-    const compilerOptions = { ...config.compilerOptions, ...options };
-    const host = ts.createCompilerHost(compilerOptions);
-
-    host.writeFile = function (fileName, contents, _writeByteOrderMark, onError, _sourceFiles) {
-        const isDts = fileName.endsWith('.d.ts');
-
-        const relativeToSourceDir = relative(sourceDir, fileName);
-        const subDir = join(targetDIR, dirname(relativeToSourceDir));
-
-        mkdirSync(subDir, { recursive: true });
-
-        let path = join(targetDIR, relativeToSourceDir);
-
-        if (!isDts && !fileName.endsWith('.map')) {
-            const astTree = parse(contents, {
-                ecmaVersion: 'latest',
-                sourceType: 'module',
-                ranges: true,
-                locations: false
-            });
-
-            switch (compilerOptions.module) {
-                case ts.ModuleKind.CommonJS: {
-                    const requireStatements = jxpath(
-                        '/**/[type=CallExpression]/callee/[type=Identifier]/[name=require]/../arguments/[type=Literal]/',
-                        astTree
-                    );
-                    // loop over all .js and change then
-
-                    for (const node of requireStatements) {
-                        node.value = resolveToFullPath(fileName, node.value, '.cjs');
-                    }
-
-                    contents = generate(astTree);
-                    path = extname(path) === '' ? path + '.cjs' : path.slice(0, -extname(path).length) + '.cjs';
-                    break;
-                }
-                case ts.ModuleKind.ES2020: {
-                    const importStatements = Array.from(jxpath('/**/[type=ImportDeclaration]/source/', astTree));
-                    for (const node of importStatements) {
-                        if (node !== null && node !== undefined) {
-                            node.value = resolveToFullPath(fileName, node.value, '.mjs');
-                        }
-                    }
-                    const exportStatements = Array.from(
-                        jxpath('/**/[type=/ExportAllDeclaration|ExportNamedDeclaration/]/source', astTree)
-                    );
-                    try {
-                        for (const node of exportStatements) {
-                            if (node !== null && node !== undefined) {
-                                node.value = resolveToFullPath(fileName, node.value, '.mjs');
-                            }
-                        }
-                    } catch (err) {
-                        console.log(err);
-                    }
-                    contents = generate(astTree);
-                    path = extname(path) === '' ? path + '.mjs' : path.slice(0, -extname(path).length) + '.mjs';
-                    break;
-                }
-                default:
-                    throw Error('Unhandled module type');
-            }
-        }
-
-        try {
-            writeFileSync(path, contents, 'utf-8');
-            // eslint-disable-next-line no-console
-            console.log('Built', path);
-        } catch (err) {
-            onError && onError(err.message);
-            // eslint-disable-next-line no-console
-            console.log('Fail', path);
-        }
-    }; // host.writeFile function definition end
-
-    const program = ts.createProgram(files, compilerOptions, host);
-    program.emit();
-}
-
-// note: this is *.ts source code so...
 function resolveToFullPath(module, importStatement, forceExt) {
     const node_m = 'node_modules';
     if (!importStatement.startsWith('./') && !importStatement.startsWith('../')) {
@@ -216,3 +94,132 @@ function resolveToFullPath(module, importStatement, forceExt) {
     // must return without extension
     return (ext === '' ? importStatement : importStatement.slice(0, -ext.length)) + forceExt;
 }
+
+/**
+ * Compiles files to JavaScript.
+ *
+ * @param {string[]} files
+ * @param {ts.CompilerOptions} options
+ */
+function createCompiler(config, sourceDir) {
+    return function compile(files, targetDIR, options) {
+        const compilerOptions = { ...config.compilerOptions, ...options };
+        const host = ts.createCompilerHost(compilerOptions);
+        let nr = 0;
+        host.writeFile = function (fileName, contents, _writeByteOrderMark, onError, _sourceFiles) {
+            const isDts = fileName.endsWith('.d.ts');
+            if (isDts && fileName.endsWith('src/lib/rng/knuth-taocp/index.js')) {
+                nr++;
+            }
+            const relativeToSourceDir = relative(sourceDir, fileName);
+            const subDir = join(targetDIR, dirname(relativeToSourceDir));
+
+            mkdirSync(subDir, { recursive: true });
+
+            let path = join(targetDIR, relativeToSourceDir);
+
+            if (!isDts && !fileName.endsWith('.map')) {
+                const astTree = parse(contents, {
+                    ecmaVersion: 'latest',
+                    sourceType: 'module',
+                    ranges: true,
+                    locations: false
+                });
+
+                switch (compilerOptions.module) {
+                    case ts.ModuleKind.CommonJS: {
+                        const requireStatements = jxpath(
+                            '/**/[type=CallExpression]/callee/[type=Identifier]/[name=require]/../arguments/[type=Literal]/',
+                            astTree
+                        );
+                        // loop over all .js and change then
+
+                        for (const node of requireStatements) {
+                            node.value = resolveToFullPath(fileName, node.value, '.cjs');
+                        }
+
+                        contents = generate(astTree);
+                        path = extname(path) === '' ? path + '.cjs' : path.slice(0, -extname(path).length) + '.cjs';
+                        break;
+                    }
+                    case ts.ModuleKind.ES2020: {
+                        const importStatements = Array.from(jxpath('/**/[type=ImportDeclaration]/source/', astTree));
+                        for (const node of importStatements) {
+                            if (node !== null && node !== undefined) {
+                                node.value = resolveToFullPath(fileName, node.value, '.mjs');
+                                console.log(node.value);
+                            }
+                        }
+                        const exportStatements = Array.from(
+                            jxpath('/**/[type=/ExportAllDeclaration|ExportNamedDeclaration/]/source', astTree)
+                        );
+                        try {
+                            for (const node of exportStatements) {
+                                if (node !== null && node !== undefined) {
+                                    node.value = resolveToFullPath(fileName, node.value, '.mjs');
+                                }
+                            }
+                        } catch (err) {
+                            console.log(err);
+                        }
+                        contents = generate(astTree);
+                        path = extname(path) === '' ? path + '.mjs' : path.slice(0, -extname(path).length) + '.mjs';
+                        break;
+                    }
+                    default:
+                        throw Error('Unhandled module type');
+                }
+            }
+
+            try {
+                writeFileSync(path, contents, 'utf-8');
+                // eslint-disable-next-line no-console
+                console.log('Built', path);
+            } catch (err) {
+                onError && onError(err.message);
+                // eslint-disable-next-line no-console
+                console.log('Fail', path);
+            }
+        }; // host.writeFile function definition end
+
+        const program = ts.createProgram(files, compilerOptions, host);
+        program.emit();
+    };
+}
+
+function init(targetDir, commenjsDir, esmDir) {
+    removeSafeDir(targetDir);
+    mkdirSync(commenjsDir, { recursive: true });
+    mkdirSync(esmDir, { recursive: true });
+    // Read the TypeScript config file.
+    const { config } = ts.readConfigFile('tsconfig.json', (fileName) => readFileSync(fileName).toString());
+    const sourceDir = join('src');
+    const { baseUrl, paths } = config.compilerOptions;
+
+    const compile = createCompiler(config, sourceDir);
+
+    compile(getAllRootSourceFiles(), esmDir, {
+        module: ts.ModuleKind.ES2020,
+        moduleResolution: ts.ModuleResolutionKind.NodeJs,
+        declaration: true,
+        declarationDir: './types', // this becomes ./dist/types
+        declarationMap: false,
+        removeComments: true,
+        sourceMap: false,
+        importHelpers: false,
+        outDir: undefined
+    });
+
+    compile(getAllRootSourceFiles(), commenjsDir, {
+        module: ts.ModuleKind.CommonJS,
+        moduleResolution: ts.ModuleResolutionKind.NodeJs,
+        declaration: false,
+        outDir: undefined, // this is a must!
+        declarationMap: false,
+        removeComments: true,
+        sourceMap: false,
+        importHelpers: false // commonjs sometimes needs some extra code to create analogs for esm constructs (example export * from 'xyz)
+    });
+}
+
+init('./dist', './dist/commonjs', './dist/esm');

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -5,14 +5,16 @@
 // https://www.typescriptlang.org/docs/handbook/modules/reference.html#paths
 
 
-import { readdirSync, lstatSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import { writeFileSync } from 'node:fs';
-import { join, relative, dirname, extname, resolve } from 'node:path';
+import { join, relative, dirname, extname } from 'node:path';
 import ts from 'typescript';
 import { parse } from 'acorn';
 import jxpath from '@mangos/jxpath';
 import { generate } from 'escodegen';
+import { verifyPaths, rankPaths, resolveToFullPath } from './helpers.mjs';
+
 
 function removeSafeDir(dir) {
     try {
@@ -22,82 +24,6 @@ function removeSafeDir(dir) {
     }
 }
 
-function getAllRootSourceFiles() {
-    let sourceFiles = ['./index.ts'];
-    return sourceFiles.map((f) => join('src', f));
-}
-
-function resolveToFullPath(module, importStatement, forceExt) {
-    const node_m = 'node_modules';
-    if (!importStatement.startsWith('./') && !importStatement.startsWith('../')) {
-        // dont change, this is a npm module import
-        return importStatement;
-    }
-    if (importStatement.includes(node_m)) {
-        const pos = importStatement.lastIndexOf(node_m);
-        return importStatement.slice(pos + node_m.length + 1);
-    }
-    // possible physical location of a file
-    const candidate = resolve(dirname(module), importStatement);
-    // is it a dir ?
-    let lstat = {
-        isDirectory() {
-            return false;
-        }
-    };
-    try {
-        lstat = lstatSync(candidate);
-    } catch (err) {
-        // nothing
-    }
-
-    if (lstat.isDirectory()) {
-        // try index import
-        const dirEntries = readdirSync(candidate);
-        let indexTSFileExists = '';
-        let packageJSONExists = '';
-        let indexFileExists = '';
-        for (const dirEntry of dirEntries) {
-            if (dirEntry === 'index.ts') {
-                indexTSFileExists = dirEntry;
-                continue;
-            }
-            if (dirEntry === 'package.json') {
-                packageJSONExists = dirEntry;
-                continue;
-            }
-            if (dirEntry === 'index' + forceExt) {
-                indexFileExists = dirEntry;
-                continue;
-            }
-        }
-        if (indexTSFileExists) {
-            return importStatement + '/index' + forceExt;
-        }
-        if (!indexFileExists && !packageJSONExists) {
-            throw new Error(
-                `directory import does not contain index.(js/mjs/cjs) file or package.json file ${join(
-                    importStatement
-                )}`
-            );
-        }
-        if (packageJSONExists) {
-            // let "export" or "main" property handle it
-            return importStatement;
-        }
-        // only index.js, index.cjs, index.mjs left
-        return importStatement + '/' + indexFileExists;
-    }
-    // strip optionally the extension
-    const ext = extname(candidate);
-    const fileNameWithTSExt = (ext === '' ? candidate : candidate.slice(0, -ext.length)) + '.ts';
-    lstat = lstatSync(fileNameWithTSExt);
-    if (!lstat.isFile()) {
-        throw new Error(`file does not exist: ${fileNameWithTSExt}`);
-    }
-    // must return without extension
-    return (ext === '' ? importStatement : importStatement.slice(0, -ext.length)) + forceExt;
-}
 
 /**
  * Compiles files to JavaScript.
@@ -108,6 +34,14 @@ function resolveToFullPath(module, importStatement, forceExt) {
 function createCompiler(config, sourceDir) {
     return function compile(files, targetDIR, options) {
         const compilerOptions = { ...config.compilerOptions, ...options };
+        const { baseUrl, paths } = compilerOptions;
+        const pathVerifyResult = verifyPaths(paths);
+        if (Array.isArray(pathVerifyResult)){
+            const messages = pathVerifyResult.join('\n');
+            throw new Error(message);
+        }
+        const { exactPaths, wildCardPaths } = rankPaths(paths);
+        console.log(exactPaths, wildCardPaths);
         const host = ts.createCompilerHost(compilerOptions);
         let nr = 0;
         host.writeFile = function (fileName, contents, _writeByteOrderMark, onError, _sourceFiles) {
@@ -139,7 +73,7 @@ function createCompiler(config, sourceDir) {
                         // loop over all .js and change then
 
                         for (const node of requireStatements) {
-                            node.value = resolveToFullPath(fileName, node.value, '.cjs');
+                            node.value = resolveToFullPath(fileName, node.value, '.cjs', baseUrl, paths, exactPaths, wildCardPaths);
                         }
 
                         contents = generate(astTree);
@@ -150,7 +84,7 @@ function createCompiler(config, sourceDir) {
                         const importStatements = Array.from(jxpath('/**/[type=ImportDeclaration]/source/', astTree));
                         for (const node of importStatements) {
                             if (node !== null && node !== undefined) {
-                                node.value = resolveToFullPath(fileName, node.value, '.mjs');
+                                node.value = resolveToFullPath(fileName, node.value, '.mjs', baseUrl, paths, exactPaths, wildCardPaths);
                                 console.log(node.value);
                             }
                         }
@@ -191,7 +125,7 @@ function createCompiler(config, sourceDir) {
     };
 }
 
-function init(targetDir, commenjsDir, esmDir) {
+function init(targetDir, commenjsDir, esmDir, roots) {
     removeSafeDir(targetDir);
     mkdirSync(commenjsDir, { recursive: true });
     mkdirSync(esmDir, { recursive: true });
@@ -202,7 +136,7 @@ function init(targetDir, commenjsDir, esmDir) {
 
     const compile = createCompiler(config, sourceDir);
 
-    compile(getAllRootSourceFiles(), esmDir, {
+    compile(roots, esmDir, {
         module: ts.ModuleKind.ES2020,
         moduleResolution: ts.ModuleResolutionKind.NodeJs,
         declaration: true,
@@ -214,7 +148,7 @@ function init(targetDir, commenjsDir, esmDir) {
         outDir: undefined
     });
 
-    compile(getAllRootSourceFiles(), commenjsDir, {
+    compile(roots, commenjsDir, {
         module: ts.ModuleKind.CommonJS,
         moduleResolution: ts.ModuleResolutionKind.NodeJs,
         declaration: false,
@@ -226,4 +160,4 @@ function init(targetDir, commenjsDir, esmDir) {
     });
 }
 
-init('./dist', './dist/commonjs', './dist/esm');
+init('./dist', './dist/commonjs', './dist/esm', ['./src/index.ts']);

--- a/scripts/helpers.mjs
+++ b/scripts/helpers.mjs
@@ -1,0 +1,203 @@
+import { resolve , dirname, extname } from 'node:path';
+import { lstatSync, readdirSync } from 'node:fs';
+
+export function verifyPaths(paths) {
+    if (Object.keys(paths).length === 0){
+        return true;
+    }
+    // must end with '*' or not have '*' at all
+    const errors = []
+    for (const path of Object.keys(paths)){
+        const stars = path.match(/\*/g);
+        if (stars?.length > 1){
+            errors.push(`Path has more then one "*" token: ${paths}`);
+            continue;
+        } else if (stars?.length === 1){
+            if (!path.endsWith('*')){
+                errors.push(`Path "*" token not at the end of path: ${path}`);
+                continue;
+            }
+        } else {
+            // exact paths must have only one entry
+            if (paths[path].length !== 1){
+                errors.push(`exact path aliases must have only one value: [${path}] has ${paths[path].length} values`);
+            }
+        }
+        
+    }
+    return errors.length ? errors : true;
+}
+
+function sortOnStringLengthDescending(a, b){
+    return b.length - a.length;
+}
+
+export function rankPaths(paths) {
+    // search for paths with no '*'
+    const names = Object.keys(paths);
+
+    const exactPaths = names.filter(path => /\*/.test(path) === false);
+    if (exactPaths.length){
+        // sort on lengt
+        exactPaths.sort(sortOnStringLengthDescending);
+    }
+   
+    const wildCardPaths = names.filter(path => /\*/.test(path) === true);
+    if (wildCardPaths.length){
+        // sort on lengt
+        wildCardPaths.sort(sortOnStringLengthDescending);
+    }
+    return { exactPaths, wildCardPaths };
+}
+
+function isRelativeImport(path){
+    return path.startsWith('./') || path.startsWith('../');
+}
+
+function isAliasedPath(path, exact, wildcard){
+    if (exact.includes(path)){
+        return true;
+    }
+    for (const wc of wildcard){
+        const toMatch = wc.slice(0, -1); // strip off the '*'
+        if (path.startsWith(toMatch)){
+            return true;
+        }
+        // could be a directory import
+        if (toMatch[toMatch.length - 1] === '/'){
+            if (path.startsWith(toMatch.slice(0, -1))){
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+function resolveAliasPaths(path, pathsDictionary, base, exact, wildcard, forceExt){
+    const idxExact = exact.indexOf(path);
+    if (idxExact >=  0){
+        return resolve(base, pathsDictionary[exact[idx]][0]);
+    }
+    const candidates = wildCard
+        .map(wc => {
+            const noStar = wc.slice(0, -1);
+            if (path.startsWith(noStar)){
+                return path;
+            }
+            const noSlash = noStar.slice(0, -1);
+            if (path.startsWith(noSlash)){
+                return path;
+            }
+            return null;
+        })
+        .filter (f => !!f); // remove nulls
+    
+    for (const candidate of candidates){
+        const noStar = condidate.slice(0, -1);
+        const noSlash = noStar.slice(0, -1);
+        const matchedString = path.startsWith(noStar) ? noStar : noSlash;
+
+        const possibleDirs = pathsDictionary[candidate];
+        // we have to resolve each array element untill we find it
+        for (const replace of possibleDirs){
+            const noStar = replace.splice(0, -1);
+            const dir = resolve(base, noStar);
+            // must be a dir
+            let lstat;
+            try {
+                lstat = lstatSync(candidate);
+            } catch (err) {
+                // nothing
+            }
+            if (!lstat) {
+                console.log(`lstat failed for ${candidate}`);
+                continue;
+            }
+            if (!lstat.isDirectory()){
+                console.log(`not a directory: ${candidate}`);
+                continue;
+            }
+            // so we have a directory
+
+
+        }
+    }
+    
+}
+
+export function resolveToFullPath(module, importStatement, forceExt, base, pathsDictionary, exact, wildcard) {
+    const node_m = 'node_modules';
+    const isAliased = isAliasedPath(importStatement, exact, wildcard);
+    const includesNodeModule = importStatement.includes(node_m);
+    if (!isRelativeImport(importStatement) && !isAliased) {
+        // dont change, this is a npm module import
+        return importStatement;
+    }
+    if (importStatement.includes(node_m)) {
+        const pos = importStatement.lastIndexOf(node_m);
+        return importStatement.slice(pos + node_m.length + 1);
+    }
+    if (isAliased){
+        const find = resolveAliasPaths(importStatement, pathsDictionary, base, exact.wildcard, forceExt)
+    }
+    // possible physical location of a file
+    const candidate = resolve(dirname(module), importStatement);
+    // is it a dir ?
+    let lstat = {
+        isDirectory() {
+            return false;
+        }
+    };
+    try {
+        lstat = lstatSync(candidate);
+    } catch (err) {
+        // nothing
+    }
+
+    if (lstat.isDirectory()) {
+        // try index import
+        const dirEntries = readdirSync(candidate);
+        let indexTSFileExists = '';
+        let packageJSONExists = '';
+        let indexFileExists = '';
+        for (const dirEntry of dirEntries) {
+            if (dirEntry === 'index.ts') {
+                indexTSFileExists = dirEntry;
+                continue;
+            }
+            if (dirEntry === 'package.json') {
+                packageJSONExists = dirEntry;
+                continue;
+            }
+            if (dirEntry === 'index' + forceExt) {
+                indexFileExists = dirEntry;
+                continue;
+            }
+        }
+        if (indexTSFileExists) {
+            return importStatement + '/index' + forceExt;
+        }
+        if (!indexFileExists && !packageJSONExists) {
+            throw new Error(
+                `directory import does not contain index.(js/mjs/cjs) file or package.json file ${join(
+                    importStatement
+                )}`
+            );
+        }
+        if (packageJSONExists) {
+            // let "export" or "main" property handle it
+            return importStatement;
+        }
+        // only index.js, index.cjs, index.mjs left
+        return importStatement + '/' + indexFileExists;
+    }
+    // strip optionally the extension
+    const ext = extname(candidate);
+    const fileNameWithTSExt = (ext === '' ? candidate : candidate.slice(0, -ext.length)) + '.ts';
+    lstat = lstatSync(fileNameWithTSExt);
+    if (!lstat.isFile()) {
+        throw new Error(`file does not exist: ${fileNameWithTSExt}`);
+    }
+    // must return without extension
+    return (ext === '' ? importStatement : importStatement.slice(0, -ext.length)) + forceExt;
+}

--- a/scripts/rollup.build.mjs
+++ b/scripts/rollup.build.mjs
@@ -3,11 +3,15 @@ import { builtinModules } from 'module';
 
 import terser from '@rollup/plugin-terser';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 const builtin = builtinModules.slice();
 builtin.splice(builtinModules.indexOf('crypto'), 1);
 
-import pkg from '../package.json' assert { type: 'json' };
+const pckPath = resolve('./package.json');
+
+const pkg = JSON.parse(readFileSync(pckPath));
 
 const version = pkg.version;
 
@@ -29,7 +33,6 @@ function shims() {
     return {
         name: 'stubbing for browser',
         async resolveId(source, importer) {
-            // console.log(`${importer} <- ${source}`);
             if (!importer) {
                 return null; // skip entry files
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 // R versions of log1p and hypot
 import { default as log1p } from '././lib/alt/log/log1p';

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,23 +67,6 @@ import { dweibull, pweibull, qweibull, rweibull, rweibullOne } from './lib/distr
 
 import { dwilcox, pwilcox, qwilcox, rwilcox, rwilcoxOne } from './lib/distributions/wilcoxon';
 
-//rng (uniform)
-/*import { KnuthTAOCP } from './lib/rng/knuth-taocp';
-
-import { KnuthTAOCP2002 } from './lib/rng/knuth-taocp-2002';
-import { LecuyerCMRG } from './lib/rng/lecuyer-cmrg';
-import { MersenneTwister } from './lib/rng/mersenne-twister';
-import { SuperDuper } from './lib/rng/super-duper';
-import { MarsagliaMultiCarry } from './lib/rng/marsaglia-multicarry';
-import { WichmannHill } from './lib/rng/wichmann-hill';
-*/
-//rng (normal)
-/*import { AhrensDieter } from './lib/rng/normal/ahrens-dieter';
-import { Inversion } from './lib/rng/normal/inversion';
-import { BoxMuller } from './lib/rng/normal/box-muller';
-import { BuggyKindermanRamage } from './lib/rng/normal/buggy-kinderman-ramage';
-import { KindermanRamage } from './lib/rng/normal/kinderman-ramage';
-*/
 import { default as seed } from './lib/rng/seed';
 // stubs
 import { IRNG, MessageType } from './lib/rng/irng';
@@ -235,20 +218,6 @@ const defaultObservableNoteBook = {
     qwilcox,
     rwilcox,
     rwilcoxOne,
-    // uniform rngs
-    /*KnuthTAOCP,
-    KnuthTAOCP2002,
-    MersenneTwister,
-    SuperDuper,
-    MarsagliaMultiCarry,
-    WichmannHill,
-    // normal rngs
-    AhrensDieter,
-    Inversion,
-    BoxMuller,
-    BuggyKindermanRamage,
-    KindermanRamage,
-    */
     //
     seed,
     // infrastructure
@@ -418,22 +387,6 @@ export {
     qwilcox,
     rwilcox,
     rwilcoxOne,
-    // uniforms rngs
-    /*KnuthTAOCP,
-    KnuthTAOCP2002,
-    LecuyerCMRG,
-    MersenneTwister,
-    SuperDuper,
-    MarsagliaMultiCarry,
-    WichmannHill,
-    // normal rngs
-    AhrensDieter,
-    Inversion,
-    BoxMuller,
-    BuggyKindermanRamage,
-    KindermanRamage,
-    */
-    //
     seed,
     // infrastructure
     // abstract class IRNG
@@ -444,8 +397,6 @@ export {
     IRNGNormal,
     // enums
     //
-    //globalUni,
-    //globalNorm,
     RNGkind,
     setSeed,
     randomSeed,

--- a/src/lib/chebyshev/chebyshev.ts
+++ b/src/lib/chebyshev/chebyshev.ts
@@ -3,26 +3,6 @@ import { ML_ERR_return_NAN2, lineInfo4 } from '@common/logger';
 
 const printer = debug('chebyshev_eval');
 
-/*
-export function chebyshev_init(dos: number[], nos: number, eta: number): number {
-    let retCode = 0;
-    //let ii: number;
-    let err: number;
-
-    if (nos < 1) return 0;
-
-    err = 0.0;
-
-    for (let ii = 1; ii <= nos; ii++) {
-        retCode = nos - ii;
-        err += abs(dos[retCode]);
-        if (err > eta) {
-            return retCode;
-        }
-    }
-    return retCode;
-}
-*/
 export function chebyshev_eval(x: number, a: number[], n: number): number {
     let b0: number;
     let b1: number;

--- a/src/lib/distributions/binomial-negative/__test__/dnbinom.test.ts
+++ b/src/lib/distributions/binomial-negative/__test__/dnbinom.test.ts
@@ -4,9 +4,7 @@ import { resolve } from 'path';
 import { loadData } from '@common/load';
 import { cl, select } from '@common/debug-mangos-select';
 
-//const dbinom_muDomainWarns = select('dnbinom_mu')("argument out of domain in '%s'");
 const dbinomDomainWarns = select('dnbinom')("argument out of domain in '%s'");
-//dbinom_muDomainWarns;
 
 import { dnbinom } from '..';
 import { prob2mu } from './test-helpers';

--- a/src/lib/distributions/binomial-negative/__test__/rnbinom.test.ts
+++ b/src/lib/distributions/binomial-negative/__test__/rnbinom.test.ts
@@ -2,10 +2,7 @@ import { globalUni } from '@rng/global-rng';
 
 import { cl, select } from '@common/debug-mangos-select';
 
-const rnbinomDomainWarns = select('rnbinom')("argument out of domain in '%s'");
 const rnbinomMuDomainWarns = select('rnbinom_mu')("argument out of domain in '%s'");
-rnbinomDomainWarns;
-//rnbinomMuDomainWarns;
 
 import { RNGkind, setSeed } from '@rng/global-rng';
 

--- a/src/lib/distributions/binomial/dbinom.ts
+++ b/src/lib/distributions/binomial/dbinom.ts
@@ -41,7 +41,6 @@ function dbinom_raw(x: number, n: number, p: number, q: number, give_log: boolea
     return R_D_exp(give_log, lc - 0.5 * lf);
 }
 
-//function dbinom(x: number, n: number, prob: number, log = false): number
 function dbinom(x: number, n: number, prob: number, log = false): number {
     /* NaNs propagated correctly */
     if (isNaN(x) || isNaN(n) || isNaN(prob)) return x + n + prob;

--- a/src/lib/distributions/chi-2/__test__/dchisq.test.ts
+++ b/src/lib/distributions/chi-2/__test__/dchisq.test.ts
@@ -1,6 +1,5 @@
 import { loadData } from '@common/load';
-import { cl /*select*/ } from '@common/debug-mangos-select';
-//const dchisqDomainWarns = select('dchisq')("argument out of domain in '%s'");
+import { cl } from '@common/debug-mangos-select';
 
 import { resolve } from 'path';
 import { dchisq } from '..';

--- a/src/lib/distributions/logis/__test__/dlogis.test.ts
+++ b/src/lib/distributions/logis/__test__/dlogis.test.ts
@@ -7,8 +7,6 @@ import { dlogis } from '..';
 const dLogisLogs = select('dlogis');
 const dLogisDomainWarns = dLogisLogs("argument out of domain in '%s'");
 
-//dlogis(x: number, location = 0, scale = 1, give_log = false)
-
 describe('dlogis', function () {
     describe('edge cases', () => {
         beforeEach(() => {

--- a/src/lib/distributions/normal/index.ts
+++ b/src/lib/distributions/normal/index.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 export { dnorm4 as dnorm } from './dnorm';
 export { pnorm5 as pnorm } from './pnorm';
 export { qnorm } from './qnorm';

--- a/src/lib/distributions/normal/pnorm.ts
+++ b/src/lib/distributions/normal/pnorm.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 

--- a/src/lib/distributions/normal/qnorm.ts
+++ b/src/lib/distributions/normal/qnorm.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 import { ML_ERR_return_NAN2, lineInfo4, R_Q_P01_boundaries } from '@common/logger';

--- a/src/lib/distributions/normal/rnorm.ts
+++ b/src/lib/distributions/normal/rnorm.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 

--- a/src/lib/distributions/poisson/dpois.ts
+++ b/src/lib/distributions/poisson/dpois.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 

--- a/src/lib/distributions/poisson/fsign.ts
+++ b/src/lib/distributions/poisson/fsign.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 // needed by rpois
 

--- a/src/lib/distributions/poisson/index.ts
+++ b/src/lib/distributions/poisson/index.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 export { dpois } from './dpois';
 export { ppois } from './ppois';

--- a/src/lib/distributions/poisson/ppois.ts
+++ b/src/lib/distributions/poisson/ppois.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { ML_ERR_return_NAN2, lineInfo4 } from '@common/logger';
 import { R_DT_0, R_DT_1, isFinite, floor } from '@lib/r-func';

--- a/src/lib/distributions/poisson/qpois.ts
+++ b/src/lib/distributions/poisson/qpois.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 

--- a/src/lib/distributions/poisson/rpois.ts
+++ b/src/lib/distributions/poisson/rpois.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 

--- a/src/lib/distributions/signrank/csignrank.ts
+++ b/src/lib/distributions/signrank/csignrank.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { imin2 } from '@lib/r-func';
 

--- a/src/lib/distributions/signrank/dsign.ts
+++ b/src/lib/distributions/signrank/dsign.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 import { ML_ERR_return_NAN2, lineInfo4 } from '@common/logger';

--- a/src/lib/distributions/signrank/index.ts
+++ b/src/lib/distributions/signrank/index.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 export { dsignrank } from './dsign';
 

--- a/src/lib/distributions/signrank/psign.ts
+++ b/src/lib/distributions/signrank/psign.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 import { ML_ERR_return_NAN2, lineInfo4 } from '@common/logger';

--- a/src/lib/distributions/signrank/qsign.ts
+++ b/src/lib/distributions/signrank/qsign.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 import { ML_ERR_return_NAN2, lineInfo4, R_Q_P01_check, ML_ERROR2, ME } from '@common/logger';

--- a/src/lib/distributions/signrank/rsign.ts
+++ b/src/lib/distributions/signrank/rsign.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 import { ML_ERR_return_NAN2, lineInfo4 } from '@common/logger';

--- a/src/lib/distributions/student-t/dnt.ts
+++ b/src/lib/distributions/student-t/dnt.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 import { ML_ERR_return_NAN2, lineInfo4 } from '@common/logger';

--- a/src/lib/distributions/student-t/dt.ts
+++ b/src/lib/distributions/student-t/dt.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { M_1_SQRT_2PI, M_LN_SQRT_2PI, abs, log1p, log, sqrt, exp, DBL_EPSILON } from '@lib/r-func';
 

--- a/src/lib/distributions/student-t/index.ts
+++ b/src/lib/distributions/student-t/index.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 // needed for random
 import { rchisq } from '@dist/chi-2';

--- a/src/lib/distributions/student-t/pnt.ts
+++ b/src/lib/distributions/student-t/pnt.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 import { pbeta } from '@dist/beta/pbeta';

--- a/src/lib/distributions/student-t/pt.ts
+++ b/src/lib/distributions/student-t/pt.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import lbeta from '@special/beta/lbeta';
 import { pbeta } from '@dist/beta/pbeta';

--- a/src/lib/distributions/student-t/qnt.ts
+++ b/src/lib/distributions/student-t/qnt.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 import { ML_ERR_return_NAN2, lineInfo4, R_Q_P01_boundaries } from '@common/logger';

--- a/src/lib/distributions/student-t/qt.ts
+++ b/src/lib/distributions/student-t/qt.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 

--- a/src/lib/distributions/student-t/rt.ts
+++ b/src/lib/distributions/student-t/rt.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 

--- a/src/lib/distributions/tukey/index.ts
+++ b/src/lib/distributions/tukey/index.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 export { ptukey } from './ptukey';
 export { qtukey } from './qtukey';

--- a/src/lib/distributions/tukey/ptukey.ts
+++ b/src/lib/distributions/tukey/ptukey.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 import { wprob } from './wprob';

--- a/src/lib/distributions/tukey/qtukey.ts
+++ b/src/lib/distributions/tukey/qtukey.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 

--- a/src/lib/distributions/tukey/wprob.ts
+++ b/src/lib/distributions/tukey/wprob.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { M_1_SQRT_2PI, pow, exp } from '@lib/r-func';
 import { pnorm5 as pnorm } from '@dist/normal/pnorm';

--- a/src/lib/distributions/uniform/dunif.ts
+++ b/src/lib/distributions/uniform/dunif.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 import { ML_ERR_return_NAN2, lineInfo4 } from '@common/logger';

--- a/src/lib/distributions/uniform/index.ts
+++ b/src/lib/distributions/uniform/index.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 export { dunif } from './dunif';
 export { punif } from './punif';

--- a/src/lib/distributions/uniform/punif.ts
+++ b/src/lib/distributions/uniform/punif.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 const printer = debug('punif');

--- a/src/lib/distributions/uniform/qunif.ts
+++ b/src/lib/distributions/uniform/qunif.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { ML_ERR_return_NAN2, lineInfo4, R_Q_P01_check } from '@common/logger';
 

--- a/src/lib/distributions/uniform/runif.ts
+++ b/src/lib/distributions/uniform/runif.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 import { ML_ERR_return_NAN2, lineInfo4 } from '@common/logger';

--- a/src/lib/distributions/weibull/dweibull.ts
+++ b/src/lib/distributions/weibull/dweibull.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 

--- a/src/lib/distributions/weibull/index.ts
+++ b/src/lib/distributions/weibull/index.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 export { dweibull } from './dweibull';
 export { pweibull } from './pweibull';

--- a/src/lib/distributions/weibull/pweibull.ts
+++ b/src/lib/distributions/weibull/pweibull.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 

--- a/src/lib/distributions/weibull/qweibull.ts
+++ b/src/lib/distributions/weibull/qweibull.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 

--- a/src/lib/distributions/weibull/rweibull.ts
+++ b/src/lib/distributions/weibull/rweibull.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 

--- a/src/lib/distributions/wilcoxon/WilcoxonCache.ts
+++ b/src/lib/distributions/wilcoxon/WilcoxonCache.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 type WCache = {
     [index: number]: WCache | number;

--- a/src/lib/distributions/wilcoxon/cwilcox.ts
+++ b/src/lib/distributions/wilcoxon/cwilcox.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { WilcoxonCache } from './WilcoxonCache';
 import { trunc } from '@lib/r-func';

--- a/src/lib/distributions/wilcoxon/dwilcox.ts
+++ b/src/lib/distributions/wilcoxon/dwilcox.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 

--- a/src/lib/distributions/wilcoxon/index.ts
+++ b/src/lib/distributions/wilcoxon/index.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 export { dwilcox } from './dwilcox';
 export { pwilcox } from './pwilcox';

--- a/src/lib/distributions/wilcoxon/pwilcox.ts
+++ b/src/lib/distributions/wilcoxon/pwilcox.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 import { ML_ERR_return_NAN2, lineInfo4 } from '@common/logger';

--- a/src/lib/distributions/wilcoxon/qwilcox.ts
+++ b/src/lib/distributions/wilcoxon/qwilcox.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 

--- a/src/lib/distributions/wilcoxon/rwilcox.ts
+++ b/src/lib/distributions/wilcoxon/rwilcox.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 import { ML_ERR_return_NAN2, lineInfo4, ML_ERROR2, ME } from '@common/logger';

--- a/src/lib/rng/fixup.ts
+++ b/src/lib/rng/fixup.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 export const i2_32m1 = 2.328306437080797e-10;
 

--- a/src/lib/rng/knuth-taocp-2002/index.ts
+++ b/src/lib/rng/knuth-taocp-2002/index.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { fixup } from '../fixup';
 import { IRNG } from '../irng';

--- a/src/lib/rng/knuth-taocp/index.ts
+++ b/src/lib/rng/knuth-taocp/index.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import { fixup } from '../fixup';
 import { IRNG } from '../irng';
 import type { IRNGType } from '@rng/rng-types';

--- a/src/lib/rng/knuth-taocp/taocp-1997-init.ts
+++ b/src/lib/rng/knuth-taocp/taocp-1997-init.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const { trunc } = Math;
 

--- a/src/lib/rng/lecuyer-cmrg/index.ts
+++ b/src/lib/rng/lecuyer-cmrg/index.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { IRNG } from '../irng';
 import type { IRNGType } from '@rng/rng-types';

--- a/src/lib/rng/marsaglia-multicarry/index.ts
+++ b/src/lib/rng/marsaglia-multicarry/index.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { INT_MAX } from '@lib/r-func';
 import { fixup, i2_32m1 } from '../fixup';

--- a/src/lib/rng/mersenne-twister/index.ts
+++ b/src/lib/rng/mersenne-twister/index.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 import { fixup } from '../fixup';
 import { IRNG } from '../irng';
 import type { IRNGType } from '@rng/rng-types';

--- a/src/lib/rng/normal/ahrens-dieter/index.ts
+++ b/src/lib/rng/normal/ahrens-dieter/index.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { IRNG, MessageType } from '../../irng';
 import { IRNGNormal } from '../normal-rng';

--- a/src/lib/rng/normal/box-muller/index.ts
+++ b/src/lib/rng/normal/box-muller/index.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import type { IRNGNormalType } from '@lib/rng/normal/rng-types';
 import { IRNG } from '@rng/irng';

--- a/src/lib/rng/normal/buggy-kinderman-ramage/index.ts
+++ b/src/lib/rng/normal/buggy-kinderman-ramage/index.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { IRNG, MessageType } from '@rng/irng';
 import { IRNGNormal } from '@rng/normal/normal-rng';

--- a/src/lib/rng/normal/inversion/index.ts
+++ b/src/lib/rng/normal/inversion/index.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { IRNG, MessageType } from '@rng/irng';
 import { qnorm } from '@dist/normal/qnorm';

--- a/src/lib/rng/normal/kinderman-ramage/index.ts
+++ b/src/lib/rng/normal/kinderman-ramage/index.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { IRNG, MessageType } from '@rng/irng';
 import { IRNGNormal } from '@rng/normal/normal-rng';

--- a/src/lib/rng/normal/normal-rng.ts
+++ b/src/lib/rng/normal/normal-rng.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { IRNG, MessageType } from '@rng/irng';
 import type { IRNGNormalType } from '@lib/rng/normal/rng-types';

--- a/src/lib/rng/normal/rng-types.ts
+++ b/src/lib/rng/normal/rng-types.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 export type IRNGNormalType =
     | 'AHRENS_DIETER'

--- a/src/lib/rng/super-duper/index.ts
+++ b/src/lib/rng/super-duper/index.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { fixup, i2_32m1 } from '@rng/fixup';
 import { IRNG } from '@rng/irng';

--- a/src/lib/rng/wichmann-hill/index.ts
+++ b/src/lib/rng/wichmann-hill/index.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { INT_MAX } from '@lib/r-func';
 import { fixup } from '@rng/fixup';

--- a/src/lib/stirling/index.ts
+++ b/src/lib/stirling/index.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { M_LN_SQRT_2PI, trunc, log } from '@lib/r-func';
 import { lgammafn_sign } from '@special/gamma/lgammafn_sign';

--- a/src/lib/trigonometry/cospi.ts
+++ b/src/lib/trigonometry/cospi.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 

--- a/src/lib/trigonometry/tanpi.ts
+++ b/src/lib/trigonometry/tanpi.ts
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { debug } from '@mangos/debug';
 

--- a/src/packages/common/logger.ts
+++ b/src/packages/common/logger.ts
@@ -1,6 +1,5 @@
-import { debug } from '@mangos/debug';
-import type { Printer, LineInfo } from '@mangos/debug';
-import { getLineInfo } from '@mangos/debug';
+import { debug, getLineInfo } from '@mangos/debug';
+import type { Printer, LineInfo  } from '@mangos/debug';
 
 const debug_R_Q_P01_boundaries = debug('R_Q_P01_boundaries');
 const debug_R_Q_P01_check = debug('R_Q_P01_check');

--- a/src/packages/common/logger.ts
+++ b/src/packages/common/logger.ts
@@ -23,14 +23,7 @@ export enum ME {
     ME_PRECISION = 8, //does not have "full" precision
     ME_UNDERFLOW = 16 // and underflow occured (important for IEEE)
 }
-/*
-export const min0 = (x: number, y: number): number => {
-  return x <= y ? x : y;
-};
-export const max0 = (x: number, y: number): number => {
-  return x <= y ? y : x;
-};
-*/
+
 export const mapErr = new Map([
     [ME.ME_NONE, 'No error'],
     [ME.ME_DOMAIN, "argument out of domain in '%s'"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,10 +5,6 @@
         "enable": true,
         "disableFilenameBasedTypeAcquisition": true
     },
-    "ts-node": {
-        "transpileOnly": true,
-        "require": ["typescript-transform-paths/register"]
-    },
     "compilerOptions": {
         "allowUnreachableCode": true,
         "allowUnusedLabels": true,
@@ -45,15 +41,7 @@
         "stripInternal": true,
 
         "checkJs": true,
-
-        "plugins": [
-            // Transform paths in output .js files
-            { "transform": "typescript-transform-paths" },
-
-            // Transform paths in output .d.ts files (Include this line if you output declarations files)
-            { "transform": "typescript-transform-paths", "afterDeclarations": true }
-        ],
-
+   
         "allowSyntheticDefaultImports": false,
         "esModuleInterop": false,
         "forceConsistentCasingInFileNames": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -47,9 +47,6 @@
         "checkJs": true,
 
         "plugins": [
-            {
-                "name": "typescript-eslint-language-service"
-            },
             // Transform paths in output .js files
             { "transform": "typescript-transform-paths" },
 


### PR DESCRIPTION
### fixed (Maddison Hellstrom)[github](https://github.com/b0o) 

[PR 190](https://github.com/R-js/libRmath.js/pull/190)

- `./types`  added to package.json "exports" property

### improved (Jacob Bogers <jkfbogers@gmail.com>)

-   removed `ts-patch`
-   removed `ts-node`
-   removed `prettier`
-   removed `eslint`
-   removed `babel`
-   removed `typescript-eslint`
-   removed `typescript-eslint/parser`
-   updated `typescript` to v4.5.2
-   removed `typescript-eslint-language-service`
-   removed  `typescript-transform-paths/register`
